### PR TITLE
Feature/37763 updated documentation co co pay pal mapping

### DIFF
--- a/docs/PayPal.md
+++ b/docs/PayPal.md
@@ -1510,7 +1510,11 @@ Get a User Id Token for the customer.
 
 This token is needed for vaulting payment methods.
 
-
+#### Connector workflow
+1. The connector is triggered
+2. The connector creates a request to [PayPal authentication api](https://developer.paypal.com/api/rest/authentication/), which includes
+   - customerId - retrieved from the customer object
+3. The connector updates the commercetools customer object.
 
 
 ***Endpoint:***
@@ -1565,6 +1569,14 @@ The input is a token which was generated in the frontend.
 
 This endpoint is used for vaulting payment methods.
 
+#### Connector workflow
+1. The connector receives the request that includes:
+    - id - the id for a payment token
+2. The connector creates a request to  [PayPal payment token for a given payment source](https://developer.paypal.com/docs/api/payment-tokens/v3/#payment-tokens_create), which includes
+   - customer.id - retrieved from the commercetools customer object if available
+   - payment_source.token - including the id from the request
+3. The connector updates the commercetools customer object and if provided in the response updates the PayPalUserId.
+
 
 ***Endpoint:***
 
@@ -1615,6 +1627,11 @@ Get the current list of vaulted payment methods for the customer.
 
 The list can be displayed in the frontend to reuse those payment methods.
 
+#### Connector workflow
+1. The connector is triggered
+2. The connector creates a request to [PayPal list all payment tokens endpoint](https://developer.paypal.com/docs/api/payment-tokens/v3/#customer_payment-tokens_get), which includes
+   - customer.id - retrieved from the customer object
+3. The connector updates the commercetools customer object.
 
 ***Endpoint:***
 
@@ -1663,6 +1680,12 @@ URL: {{host}}/{{project-key}}/customers/{{customer-id}}
 
 Delete a saved payment token.
 
+#### Connector workflow
+1. The connector receives the request that includes:
+    - paymentToken - the token id to be deleted
+2. The connector creates a request to [PayPal delete payment token endpoint](https://developer.paypal.com/docs/api/payment-tokens/v3/#payment-tokens_delete), which includes
+    - id - the paymentToken from the request
+3. The connector updates the commercetools customer object.
 
 ***Endpoint:***
 

--- a/docs/PayPal.md
+++ b/docs/PayPal.md
@@ -45,7 +45,13 @@ The connector is accessed through [commercetools custom fields](https://docs.com
 }
 ```
 
-The request is first sent to a commercetools relevant endpoint (e.g. payments) and the connector is triggered. The connector then processes the request and if relevant interacts with PayPal api based on request data and data available from commercetools. The response is then processed by the connector and relevant commercetools objects are updated accordingly. By default, the update just stores relevant fields from PayPal response in the custom field of the related object.
+The request is first sent to a commercetools relevant endpoint (e.g. payments), which triggers the connector. 
+
+The connector then processes the request body value according to the name of the method and if relevant interacts with PayPal api based on request data and data available from commercetools. The structure of the request to PayPal is based on the [PayPal api documentation](https://developer.paypal.com/api/rest/) and **is not identical to the commercetools request body value**.
+
+The response is then processed by the connector and relevant commercetools objects are updated accordingly. By default, the update just stores relevant fields from PayPal response in the custom field of the related object.
+
+A brief description of the connector workflow including values supported in commercetools request and/or passed to the PayPal is provided for each method that interacts with PayPal api. For the exact structure of the request to PayPal including details on if the value is passed in the body, path or header please refer to the [PayPal api documentation](https://developer.paypal.com/api/rest/).
 
 ## Endpoints
 

--- a/docs/PayPal.md
+++ b/docs/PayPal.md
@@ -45,7 +45,7 @@ The connector is accessed through [commercetools custom fields](https://docs.com
 }
 ```
 
-The request is first sent to a commercetools relevant endpoint (e.g. payments) and the connector is triggered. The connector then processes the request and if relevant interacts with PayPal api based on request data and data available from commercetools. The response is then processed by the connector and relevant commercetools objects are updated accordingly.
+The request is first sent to a commercetools relevant endpoint (e.g. payments) and the connector is triggered. The connector then processes the request and if relevant interacts with PayPal api based on request data and data available from commercetools. The response is then processed by the connector and relevant commercetools objects are updated accordingly. By default, the update just stores relevant fields from PayPal response in the custom field of the related object.
 
 ## Endpoints
 

--- a/docs/PayPal.md
+++ b/docs/PayPal.md
@@ -233,23 +233,21 @@ URL: {{auth_url}}/oauth/introspect
 
 Create a PayPal Order.
 
-This call addresses PayPal commercetools connector to request a PayPal order creation.
-
 Payment source is the only required parameter in the request. For each supported payment method the example call with a valid payment_source is provided.
 
 Additional fields might be relevant for certain payment methods (e.g. PayUponInvoice).
 
 If the request is correct - the PayPal endpoint [Create Order](https://developer.paypal.com/docs/api/orders/v2/#orders_create) will be called .
 
-#### Workflow
+#### Connector workflow
 
-1. commercetools endpoint "custom objects" is called with a request, that triggers create PayPal order call. The request includes:
+1. The connector receives a request that includes:
    - payment_source (mandatory) - the payment source object, it must contain the method name and the necessary data, that can't be retrieved from commercetools cart or payment.
    - clientMetadataId (ony for PayUponInvoice) - see details in the [PayPal documentation](https://developer.paypal.com/docs/checkout/apm/pay-upon-invoice/fraudnet/)
    - custom_invoice_id (optional) - will be passed to PayPal as purchase_units.invoice_id if sent
    - storeInVaultOnSuccess (optional) - will trigger the connector to store the payment source in the vault if the payment source is "paypal", "venmo" or "card"
    - any other data that match [PayPal Order body specification](https://developer.paypal.com/docs/api/orders/v2/#orders_create). **In this case no mapping from commercetools will be available.**
-2. the connector creates a request to PayPal orders api, in which includes all relevant fields from the previous step and provides the mapping for other fields, namely:
+2. The connector creates a request to PayPal orders api, in which includes all relevant fields from the previous step and provides the mapping for other fields, namely:
    - purchase_units: will be set based on commercetools cart and commercetools payment unless other value is sent in the request. **Note**: the whole purchase_units array will be overwritten in this case. The following parameters are mapped by default:
      - description - if possible will be retrieved from commercetools PayPal settings, if not based on cart
      - invoice_id - custom_invoice_id if sent in the request, otherwise commercetools payment id
@@ -264,8 +262,8 @@ If the request is correct - the PayPal endpoint [Create Order](https://developer
    - payment_source - if relevant for the method the value will be updated to include the necessary fields, namely:
      * for PayUponInvoice - birth_date and phone must be provided in the request, if other parameters are not provided - they will be defined based on commercetools cart and PayPal settings
      * if commercetools shipping address is provided - experience_context.shipping_preference will be set to 'SET_PROVIDED_ADDRESS', unless different value is sent in the request
-3. if storeInVaultOnSuccess was requested and payment source is "paypal", "vemno" or "card" the connector will attempt to retrieve the commercetools user PayPalUserId and will add to the request body the fields necessary for vaulting the relevant method.
-4. the connector sends the request to PayPal and on success updates the commercetools payment.
+3. If storeInVaultOnSuccess was requested and payment source is "paypal", "vemno" or "card" the connector will attempt to retrieve the commercetools user PayPalUserId and will add to the request body the fields necessary for vaulting the relevant method.
+4. The connector sends the request to PayPal and on success updates the commercetools payment.
 
 ***Endpoint:***
 

--- a/docs/PayPal.md
+++ b/docs/PayPal.md
@@ -1272,7 +1272,7 @@ The payment needs at least one capture transaction. If there are multiple transa
 1. The connector receives the request that includes:
     - amount(optional) - PayPal [amount.value](https://developer.paypal.com/docs/api/payments/v2/#captures_refund) to be refunded
     - captureId(optional) - the capture id to be refunded.
-2. The connector constructs and sends the request to PayPal refund captured payment endpoint(https://developer.paypal.com/docs/api/payments/v2/#captures_refund), including:
+2. The connector constructs and sends the request to [PayPal refund captured payment endpoint](https://developer.paypal.com/docs/api/payments/v2/#captures_refund), including:
     - capture_id - if not provided in the request the capture_id will be read from the payment transactions
     - amount (only if received in the request) - if the value is provided in the request the currency code will be taken from the commercetools payment object
 3. The connector updates the commercetools payment object and adds a transaction to it. Transaction data depend on the PayPal response.

--- a/docs/PayPal.md
+++ b/docs/PayPal.md
@@ -773,7 +773,14 @@ URL: {{host}}/{{project-key}}/payments/{{payment-id}}
 
 Authorize an order.
 
-The order id will be read from the payment object.
+If not provided the order id will be read from the payment object.
+
+#### Connector Workflow
+1. The connector receives the request that includes:
+    - orderId(optional) - the order id to be captured.
+    - any other data that match [PayPal Authorize order body specification](https://developer.paypal.com/docs/api/orders/v2/#orders_authorize).
+2. If not provided in the request the order_id will be read from the payment and PayPal api authorize order will be triggered with the id and any other passed data.
+3. The connector updates commercetools payment object and adds a transaction to it. Transaction data depend on the PayPal response.
 
 
 ***Endpoint:***
@@ -823,8 +830,13 @@ URL: {{host}}/{{project-key}}/payments/{{payment-id}}
 
 Get Order details.
 
-The order id will be read from the payment object.
+If not provided the order id will be read from the payment object.
 
+#### Connector Workflow
+1. The connector receives the request that includes:
+    - orderId(optional) - the order id to be retrieved.
+2. If not provided in the request the order_id will be read from the payment and PayPal api authorize order will be triggered with the id and any other passed data.
+3. The connector updates commercetools payment object.
 
 ***Endpoint:***
 
@@ -873,7 +885,13 @@ URL: {{host}}/{{project-key}}/payments/{{payment-id}}
 
 Get Capture details.
 
-The payment needs at least one capture transaction. If there are multiple transactions, the newest one will be refunded.
+The payment needs at least one capture transaction. If there are multiple transactions and no specific captureId is provided, the newest one will be refunded.
+
+#### Connector Workflow
+1. The connector receives the request that includes:
+    - captureId(optional) - the order id to be retrieved.
+2. If not provided in the request the order_id will be read from the payment and PayPal api authorize order will be triggered with the id and any other passed data.
+3. The connector updates commercetools payment object.
 
 
 ***Endpoint:***

--- a/docs/PayPal.md
+++ b/docs/PayPal.md
@@ -33,6 +33,19 @@ To automate frequent tasks the collection automatically manages commonly require
 
 Please see [http://docs.commercetools.com/](http://docs.commercetools.com/) for further information about the commercetools platform.
 
+## General Workflow
+
+The connector is accessed through [commercetools custom fields](https://docs.commercetools.com/api/projects/custom-fields#customfields). Therefore, all calls that trigger the connector include an object of the following structure:
+
+```json
+{
+  "action": "setCustomField",
+  "name": **connector method that will be triggered**,
+  "value": **actual body with which the connector will be triggered**
+}
+```
+
+The request is first sent to a commercetools relevant endpoint (e.g. payments) and the connector is triggered. The connector then processes the request and if relevant interacts with PayPal api based on request data and data available from commercetools. The response is then processed by the connector and relevant commercetools objects are updated accordingly.
 
 ## Endpoints
 

--- a/docs/PayPal.md
+++ b/docs/PayPal.md
@@ -557,6 +557,11 @@ Returns a string which contains all authorization and configuration
 information that your client needs to initialize the client SDK to  
 communicate with PayPal.
 
+#### Connector workflow
+1. The connector attempts to retrieve cached commercetools PayPal access token.
+2. If the cached token is not available a new token is generated.
+3. [PayPal Authentication](https://developer.paypal.com/api/rest/authentication/) is triggered.
+4. On success updates the commercetools payment object.
 
 ***Endpoint:***
 

--- a/docs/PayPal.md
+++ b/docs/PayPal.md
@@ -612,7 +612,7 @@ Capture an order. If not provided the Order Id will be read from the payment obj
 
 #### Connector workflow
 1. The connector receives the request that includes:
-   - order_id(optional) - the order id to be captured. 
+   - orderId(optional) - the order id to be captured. 
    - any other data that match [PayPal Capture Order body specification](https://developer.paypal.com/docs/api/orders/v2/#orders_capture). 
 2. If not provided in the request the order_id will be read from the payment object and PayPal api Captrure Order will be triggered with the id and any other passed data.
 3. The connector updates commercetools payment object and adds a transaction to it. Transaction data depend on the PayPal response.
@@ -669,7 +669,7 @@ If not provided the authorization id will be read from the payment transactions.
 
 #### Connector Workflow
 1. The connector receives the request that includes:
-   - authorization_id(optional) - the authorization id to be captured.
+   - authorizationId(optional) - the authorization id to be captured.
    - any other data that match [PayPal Capture authorized payment body specification](https://developer.paypal.com/docs/api/payments/v2/#authorizations_capture).
 2. If not provided in the request the authorization_id will be read from the payment transactions and PayPal api Capture Authorization will be triggered with the id and any other passed data.
 3. The connector updates commercetools payment object and adds a transaction to it. Transaction data depend on the PayPal response.
@@ -723,7 +723,7 @@ If not provided authorization id will be read from the payment transactions.
 
 #### Connector Workflow
 1. The connector receives the request that includes:
-    - authorization_id(optional) - the authorization id to be captured.
+    - authorizationId(optional) - the authorization id to be captured.
 2. If not provided in the request the authorization_id will be read from the payment transactions and [PayPal api](https://developer.paypal.com/docs/api/payments/v2/#authorizations_void) will be triggered with the id.
 3. The connector updates commercetools payment object and adds a transaction to it. Transaction data depend on the PayPal response.
 

--- a/docs/PayPal.md
+++ b/docs/PayPal.md
@@ -1,9 +1,9 @@
 
-# Commercetools
+# commercetools
 
-# PayPal Commercetools API Postman collection
+# PayPal commercetools API Postman collection
 
-This Postman collection contains examples of requests and responses for most endpoints and commands of the PayPal extension for Commercetools. The extension provides communication to PayPal based on commercetools infrastructure, so if relevant the relation between PayPal and commercetools entities is mentioned.
+This Postman collection contains examples of requests and responses for most endpoints and commands of the PayPal extension for commercetools. The extension provides communication to PayPal based on commercetools infrastructure, so if relevant the relation between PayPal and commercetools entities is mentioned.
 
 For every command the smallest possible payload is given. Please find optional fields in the related official documentation.
 
@@ -43,12 +43,12 @@ The connector is accessed through [commercetools custom fields](https://docs.com
    - value: will be sent to the connector as a new request (req2) body
 2. The connector method req1.name is triggered by commercetools with the new request (req2).
 3. If necessary the connector acquires additional data from commercetools (d).
-4. The data from req2 and d are processed to create a new request (req3) to PayPal. The structure of the request to PayPal is based on the [PayPal api documentation](https://developer.paypal.com/api/rest/) and **is not identical to the commercetools request body value**. Some of the data may be passed as path or header parameters.
+4. The data from req2 and d are processed to create a new request (req3) to PayPal. The structure of the request to PayPal is based on the [PayPal API documentation](https://developer.paypal.com/api/rest/) and **is not identical to the commercetools request body value**. Some of the data may be passed as path or header parameters.
 5. The connector receives the response from PayPal (res1).
 6. The connector updates relevant commercetools objects (o). By default, relevant data from res1 are stored in the custom field of the related object. 
 
 
-For the methods that interact with PayPal api this documentation includes "Connector workflow" section. This section describes:
+For the methods that interact with PayPal API this documentation includes "Connector workflow" section. This section describes:
     
 - supported request parameters (res1.value)
 - collected commercetools data (d)
@@ -97,7 +97,7 @@ For the methods that interact with PayPal api this documentation includes "Conne
 
 ## Authorization
 
-All the calls in this section are only relevant for commercetools. Autentication for communication with PayPal is covered in the next section.
+All the calls in this section are only relevant for commercetools. Authentication for communication with PayPal is covered in the next section.
 
 ### 1. Obtain access token
 
@@ -245,7 +245,7 @@ Payment source is the only required parameter in the request. For each supported
 
 Additional fields might be relevant for certain payment methods (e.g. PayUponInvoice).
 
-If the request is correct - the PayPal endpoint [Create Order](https://developer.paypal.com/docs/api/orders/v2/#orders_create) will be called .
+If the request is correct - the PayPal endpoint [Create Order](https://developer.paypal.com/docs/api/orders/v2/#orders_create) will be called.
 
 #### Connector workflow
 
@@ -255,7 +255,7 @@ If the request is correct - the PayPal endpoint [Create Order](https://developer
    - custom_invoice_id (optional) - will be passed to PayPal as purchase_units.invoice_id if sent
    - storeInVaultOnSuccess (optional) - will trigger the connector to store the payment source in the vault if the payment source is "paypal", "venmo" or "card"
    - optional any other data that match [PayPal Order body specification](https://developer.paypal.com/docs/api/orders/v2/#orders_create). **In this case no mapping from commercetools will be available.**
-2. The connector creates a request to PayPal orders api, in which includes all relevant fields from the previous step and provides the mapping for other fields, namely:
+2. The connector creates a request to PayPal orders API, in which includes all relevant fields from the previous step and provides the mapping for other fields, namely:
    - purchase_units: will be set based on commercetools cart and commercetools payment unless other value is sent in the request. **Note**: the whole purchase_units array will be overwritten in this case. The following parameters are mapped by default:
      - description - if possible will be retrieved from commercetools PayPal settings, if not based on cart
      - invoice_id - custom_invoice_id if sent in the request, otherwise commercetools payment id
@@ -616,13 +616,13 @@ URL: {{host}}/{{project-key}}/payments/{{payment-id}}
 
 ### 3. CaptureOrder
 
-Capture an order. If not provided the Order Id will be read from the payment object.
+Capture an order. If not provided the order Id will be read from the payment object.
 
 #### Connector workflow
 1. The connector receives the request that includes:
    - orderId(optional) - the order id to be captured. 
    - optional any other data that match [PayPal Capture Order body specification](https://developer.paypal.com/docs/api/orders/v2/#orders_capture). 
-2. If not provided in the request the order_id will be read from the payment object and PayPal api Captrure Order will be triggered with the id and any other passed data.
+2. If not provided in the request the order_id will be read from the payment object and PayPal API Captrure Order will be triggered with the id and any other passed data.
 3. The connector updates commercetools payment object and adds a transaction to it. Transaction data depend on the PayPal response.
 
 ***Endpoint:***
@@ -679,7 +679,7 @@ If not provided the authorization id will be read from the payment transactions.
 1. The connector receives the request that includes:
    - authorizationId(optional) - the authorization id to be captured.
    - optional any other data that match [PayPal Capture authorized payment body specification](https://developer.paypal.com/docs/api/payments/v2/#authorizations_capture).
-2. If not provided in the request the authorization_id will be read from the payment transactions and PayPal api Capture Authorization will be triggered with the id and any other passed data.
+2. If not provided in the request the authorization_id will be read from the payment transactions and PayPal API Capture Authorization will be triggered with the id and any other passed data.
 3. The connector updates commercetools payment object and adds a transaction to it. Transaction data depend on the PayPal response.
 
 ***Endpoint:***
@@ -732,7 +732,7 @@ If not provided authorization id will be read from the payment transactions.
 #### Connector Workflow
 1. The connector receives the request that includes:
     - authorizationId(optional) - the authorization id to be captured.
-2. If not provided in the request the authorization_id will be read from the payment transactions and [PayPal api](https://developer.paypal.com/docs/api/payments/v2/#authorizations_void) will be triggered with the id.
+2. If not provided in the request the authorization_id will be read from the payment transactions and [PayPal API](https://developer.paypal.com/docs/api/payments/v2/#authorizations_void) will be triggered with the id.
 3. The connector updates commercetools payment object and adds a transaction to it. Transaction data depend on the PayPal response.
 
 
@@ -787,7 +787,7 @@ If not provided the order id will be read from the payment object.
 1. The connector receives the request that includes:
     - orderId(optional) - the order id to be captured.
     - optional any other data that match [PayPal Authorize order body specification](https://developer.paypal.com/docs/api/orders/v2/#orders_authorize).
-2. If not provided in the request the order_id will be read from the payment and PayPal api authorize order will be triggered with the id and any other passed data.
+2. If not provided in the request the order_id will be read from the payment and PayPal API authorize order will be triggered with the id and any other passed data.
 3. The connector updates commercetools payment object and adds a transaction to it. Transaction data depend on the PayPal response.
 
 
@@ -843,7 +843,7 @@ If not provided the order id will be read from the payment object.
 #### Connector Workflow
 1. The connector receives the request that includes:
     - orderId(optional) - the order id to be retrieved.
-2. If not provided in the request the order_id will be read from the payment and PayPal api authorize order will be triggered with the id and any other passed data.
+2. If not provided in the request the order_id will be read from the payment and PayPal API authorize order will be triggered with the id and any other passed data.
 3. The connector updates commercetools payment object.
 
 ***Endpoint:***
@@ -898,7 +898,7 @@ The payment needs at least one capture transaction. If there are multiple transa
 #### Connector Workflow
 1. The connector receives the request that includes:
     - captureId(optional) - the order id to be retrieved.
-2. If not provided in the request the order_id will be read from the payment and PayPal api authorize order will be triggered with the id and any other passed data.
+2. If not provided in the request the order_id will be read from the payment and PayPal API authorize order will be triggered with the id and any other passed data.
 3. The connector updates commercetools payment object.
 
 

--- a/docs/PayPal.md
+++ b/docs/PayPal.md
@@ -35,23 +35,25 @@ Please see [http://docs.commercetools.com/](http://docs.commercetools.com/) for 
 
 ## General Workflow
 
-The connector is accessed through [commercetools custom fields](https://docs.commercetools.com/api/projects/custom-fields#customfields). Therefore, all calls that trigger the connector include an object of the following structure:
+The connector is accessed through [commercetools custom fields](https://docs.commercetools.com/api/projects/custom-fields#customfields). Therefore, the general workflow for the connector is as follows: 
 
-```json
-{
-  "action": "setCustomField",
-  "name": **connector method that will be triggered**,
-  "value": **actual body with which the connector will be triggered**
-}
-```
+1. commercetools receives the request (req1) with:
+   - action : "setCustomField" 
+   - name: connector method that should be triggered
+   - value: will be sent to the connector as a new request (req2) body
+2. The connector method req1.name is triggered by commercetools with the new request (req2).
+3. If necessary the connector acquires additional data from commercetools (d).
+4. The data from req2 and d are processed to create a new request (req3) to PayPal. The structure of the request to PayPal is based on the [PayPal api documentation](https://developer.paypal.com/api/rest/) and **is not identical to the commercetools request body value**. Some of the data may be passed as path or header parameters.
+5. The connector receives the response from PayPal (res1).
+6. The connector updates relevant commercetools objects (o). By default, relevant data from res1 are stored in the custom field of the related object. 
 
-The request is first sent to a commercetools relevant endpoint (e.g. payments), which triggers the connector. 
 
-The connector then processes the request body value according to the name of the method and if relevant interacts with PayPal api based on request data and data available from commercetools. The structure of the request to PayPal is based on the [PayPal api documentation](https://developer.paypal.com/api/rest/) and **is not identical to the commercetools request body value**.
-
-The response is then processed by the connector and relevant commercetools objects are updated accordingly. By default, the update just stores relevant fields from PayPal response in the custom field of the related object.
-
-A brief description of the connector workflow including values supported in commercetools request and/or passed to the PayPal is provided for each method that interacts with PayPal api. For the exact structure of the request to PayPal including details on if the value is passed in the body, path or header please refer to the [PayPal api documentation](https://developer.paypal.com/api/rest/).
+For the methods that interact with PayPal api this documentation includes "Connector workflow" section. This section describes:
+    
+- supported request parameters (res1.value)
+- collected commercetools data (d)
+- data sent to PayPal (req3)
+- updated commercetools object (o) and any custom updates
 
 ## Endpoints
 

--- a/docs/PayPal.md
+++ b/docs/PayPal.md
@@ -608,9 +608,14 @@ URL: {{host}}/{{project-key}}/payments/{{payment-id}}
 
 ### 3. CaptureOrder
 
+Capture an order. If not provided the Order Id will be read from the payment object.
 
-Capture an order. The Order Id will be read from the payment object.
-
+#### Connector workflow
+1. The connector receives the request that includes:
+   - order_id(optional) - the order id to be captured. 
+   - any other data that match [PayPal Capture Order body specification](https://developer.paypal.com/docs/api/orders/v2/#orders_capture). 
+2. If not provided in the request the order_id will be read from the payment object and PayPal api Captrure Order will be triggered with the id and any other passed data.
+3. The connector adds a transaction the commercetools payment object. Transaction data depend on the PayPal response.
 
 ***Endpoint:***
 

--- a/docs/PayPal.md
+++ b/docs/PayPal.md
@@ -615,7 +615,7 @@ Capture an order. If not provided the Order Id will be read from the payment obj
    - order_id(optional) - the order id to be captured. 
    - any other data that match [PayPal Capture Order body specification](https://developer.paypal.com/docs/api/orders/v2/#orders_capture). 
 2. If not provided in the request the order_id will be read from the payment object and PayPal api Captrure Order will be triggered with the id and any other passed data.
-3. The connector adds a transaction the commercetools payment object. Transaction data depend on the PayPal response.
+3. The connector updates commercetools payment object and adds a transaction to it. Transaction data depend on the PayPal response.
 
 ***Endpoint:***
 
@@ -665,8 +665,14 @@ URL: {{host}}/{{project-key}}/payments/{{payment-id}}
 
 Capture an authorization.
 
-The authorization id will be read from the payment transactions.
+If not provided the authorization id will be read from the payment transactions.
 
+#### Connector Workflow
+1. The connector receives the request that includes:
+   - authorization_id(optional) - the authorization id to be captured.
+   - any other data that match [PayPal Capture authorized payment body specification](https://developer.paypal.com/docs/api/payments/v2/#authorizations_capture).
+2. If not provided in the request the authorization_id will be read from the payment transactions and PayPal api Capture Authorization will be triggered with the id and any other passed data.
+3. The connector updates commercetools payment object and adds a transaction to it. Transaction data depend on the PayPal response.
 
 ***Endpoint:***
 
@@ -713,7 +719,13 @@ URL: {{host}}/{{project-key}}/payments/{{payment-id}}
 
 Void an authorization.
 
-The authorization id will be read from the payment transactions.
+If not provided authorization id will be read from the payment transactions.
+
+#### Connector Workflow
+1. The connector receives the request that includes:
+    - authorization_id(optional) - the authorization id to be captured.
+2. If not provided in the request the authorization_id will be read from the payment transactions and [PayPal api](https://developer.paypal.com/docs/api/payments/v2/#authorizations_void) will be triggered with the id.
+3. The connector updates commercetools payment object and adds a transaction to it. Transaction data depend on the PayPal response.
 
 
 **_Endpoint:_**

--- a/docs/workflows/sequence_diagram_paypal_payment.md
+++ b/docs/workflows/sequence_diagram_paypal_payment.md
@@ -19,7 +19,7 @@ sequenceDiagram
     Note over CoCo, PayPal: PayPal orders v2 API
     Note over frontend, CoCo: Cart is created by built in CoFe methods and has products and user data in it
     frontend-->>backend: getSettings action
-    backend-->>CoCo: getSetting request
+    backend-->>CoCo: getSettings request
     Note over backend, CoCo: endpoint >custom-objects/<br/>paypal-commercetools-connector
     CoCo-->>backend: GetSettingsResponse
     backend-->>frontend: GetSettingsResponse, Session data


### PR DESCRIPTION
The goal of this PR is:
- indicate what can be passed to the request to commercetools connector
- indicate what will be sent at the end to PayPal

it is dedicated for planning the next update for including support for PayPal standard fields like "custom_id"