### PR TITLE
Bugfix/37822 webhook id missing

### DIFF
--- a/paypal-commercetools-extension/src/connector/pre-undeploy.ts
+++ b/paypal-commercetools-extension/src/connector/pre-undeploy.ts
@@ -20,11 +20,10 @@ async function preUndeploy(properties: Map<string, unknown>): Promise<void> {
   const apiRoot = createApiRoot();
   const applicationUrl = properties.get(CONNECT_APPLICATION_URL_KEY);
   assertString(applicationUrl, CONNECT_APPLICATION_URL_KEY);
-
   await deleteAccessTokenIfExists();
+  await deleteWebhook();
   await deleteExtension(apiRoot, PAYPAL_PAYMENT_EXTENSION_KEY, applicationUrl);
   await deleteExtension(apiRoot, PAYPAL_CUSTOMER_EXTENSION_KEY, applicationUrl);
-  await deleteWebhook();
 }
 
 async function run(): Promise<void> {

--- a/paypal-commercetools-extension/src/service/paypal.service.ts
+++ b/paypal-commercetools-extension/src/service/paypal.service.ts
@@ -35,6 +35,7 @@ import { PAYPAL_WEBHOOKS_PATH } from '../routes/webhook.route';
 import { Order } from '../types/index.types';
 import { logger } from '../utils/logger.utils';
 import { cacheAccessToken, getCachedAccessToken } from './config.service';
+import { getPayPalExtensionUrl } from './commercetools.service';
 
 const PAYPAL_API_SANDBOX = 'https://api-m.sandbox.paypal.com';
 const PAYPAL_API_LIVE = 'https://api-m.paypal.com';
@@ -376,7 +377,7 @@ export const createWebhook = async () => {
   }
   const gateway = await getPayPalWebhooksGateway();
   const response = await gateway.webhooksPost({
-    url: getWebhookUrl(),
+    url: await getWebhookUrl(),
     event_types: [
       {
         name: '*',
@@ -405,7 +406,7 @@ export const deleteWebhook = async () => {
 };
 
 export const getWebhookId = async () => {
-  const webhookUrl = getWebhookUrl();
+  const webhookUrl = await getWebhookUrl();
   const gateway = await getPayPalWebhooksGateway();
   const webhooks = await gateway.webhooksList('APPLICATION');
   const webhook = webhooks.data.webhooks?.find(
@@ -414,13 +415,10 @@ export const getWebhookId = async () => {
   return webhook?.id;
 };
 
-export const getWebhookUrl = () => {
-  return (
-    process.env.CONNECT_SERVICE_URL?.replace(
-      PAYPAL_EXTENSION_PATH,
-      PAYPAL_WEBHOOKS_PATH
-    ) ?? ''
-  );
+export const getWebhookUrl = async () => {
+  const extensionUrl =
+    process.env.CONNECT_SERVICE_UR ?? (await getPayPalExtensionUrl());
+  return extensionUrl.replace(PAYPAL_EXTENSION_PATH, PAYPAL_WEBHOOKS_PATH);
 };
 
 export const addDeliveryData = async (

--- a/paypal-commercetools-extension/src/service/paypal.service.ts
+++ b/paypal-commercetools-extension/src/service/paypal.service.ts
@@ -416,9 +416,14 @@ export const getWebhookId = async () => {
 };
 
 export const getWebhookUrl = async () => {
-  const extensionUrl =
-    process.env.CONNECT_SERVICE_UR ?? (await getPayPalExtensionUrl());
-  return extensionUrl.replace(PAYPAL_EXTENSION_PATH, PAYPAL_WEBHOOKS_PATH);
+  try {
+    const extensionUrl =
+      process.env.CONNECT_SERVICE_UR ?? (await getPayPalExtensionUrl());
+    return extensionUrl.replace(PAYPAL_EXTENSION_PATH, PAYPAL_WEBHOOKS_PATH);
+  } catch (e) {
+    logger.info('no webhook url identified');
+    return '';
+  }
 };
 
 export const addDeliveryData = async (

--- a/paypal-commercetools-extension/tests/post-deploy.spec.ts
+++ b/paypal-commercetools-extension/tests/post-deploy.spec.ts
@@ -30,6 +30,7 @@ function sleep(milliseconds: number) {
 
 describe('Testing post deploy', () => {
   test('Testing post deploy with no registered webhook', async () => {
+    process.env.CONNECT_SERVICE_UR = 'https://lorem.ipsum';
     const webhooksApi = {
       webhooksList: jest.fn(() => ({ data: { webhooks: [] } })),
       webhooksPost: jest.fn(() => ({ data: { id: 1 } })),

--- a/paypal-commercetools-extension/tests/pre-undeploy.spec.ts
+++ b/paypal-commercetools-extension/tests/pre-undeploy.spec.ts
@@ -40,6 +40,7 @@ function sleep(milliseconds: number) {
 
 describe('Testing pre undeploy', () => {
   test('Testing pre undeploy', async () => {
+    process.env.CONNECT_SERVICE_UR = 'https://lorem.ipsum';
     require('../src/connector/pre-undeploy');
     await sleep(5000);
     expect(apiRoot.delete).toBeCalledTimes(3);


### PR DESCRIPTION
ct have agreed that the environmental variable for the url where everything is hosted should be available all the time (now it is granted only for post-deploy and pre-undeploy steps) and they will provide the fix in foreseen future, so this is just a temporal fallback while they are working on it. Also self-hosted connectors have this env variable already.