### PR TITLE
37928 - assign payment to store if relevant on create an access token…

### DIFF
--- a/paypal-commercetools-extension/src/service/payments.service.ts
+++ b/paypal-commercetools-extension/src/service/payments.service.ts
@@ -277,7 +277,7 @@ export const handleCreateOrderRequest = async (
         name: 'PayPalCustomId',
         value: customId,
       });
-    if (storeKey && !payment.custom.fields.storeKey)
+    if (storeKey && !payment?.custom?.fields?.storeKey)
       updateActions.push({
         action: 'setCustomField',
         name: 'storeKey',
@@ -520,10 +520,10 @@ export async function handleGetClientTokenRequest(payment?: Payment) {
     return [];
   }
   let updateActions: UpdateActions = [];
-  let storeKey = payment?.custom?.fields.storeKey;
+  let storeKey = payment.custom?.fields?.storeKey;
   if (!storeKey) {
     const cart = await getCart(payment.id);
-    if (!storeKey && cart.store?.key) {
+    if (cart?.store?.key) {
       storeKey = cart.store.key;
       updateActions.push({
         action: 'setCustomField',

--- a/paypal-commercetools-extension/src/service/paypal.service.ts
+++ b/paypal-commercetools-extension/src/service/paypal.service.ts
@@ -227,7 +227,7 @@ export const refundPayPalOrder = async (
 };
 
 export async function getClientToken(storeKey?: string) {
-  logger.info(`requested token for ${storeKey ? storeKey : 'default'} store `);
+  logger.info(`requested token for ${storeKey ? storeKey : 'default'} store`);
   const token = await generateAccessToken(storeKey);
   const options = {
     method: 'POST',

--- a/paypal-commercetools-extension/src/service/paypal.service.ts
+++ b/paypal-commercetools-extension/src/service/paypal.service.ts
@@ -227,6 +227,7 @@ export const refundPayPalOrder = async (
 };
 
 export async function getClientToken(storeKey?: string) {
+  logger.info(`requested token for ${storeKey ? storeKey : 'default'} store `);
   const token = await generateAccessToken(storeKey);
   const options = {
     method: 'POST',

--- a/paypal-commercetools-extension/tests/payment.controller.spec.ts
+++ b/paypal-commercetools-extension/tests/payment.controller.spec.ts
@@ -104,6 +104,7 @@ describe('Testing Braintree GetClient Token', () => {
   test('create client token for default PayPal credentials', async () => {
     const paymentRequest = {
       obj: {
+        id: 'paymentOutOfStore',
         custom: {
           fields: {
             getClientTokenRequest: '{}',
@@ -113,13 +114,26 @@ describe('Testing Braintree GetClient Token', () => {
     } as unknown as PaymentReference;
     await expectClientTokenRequest(paymentRequest);
   }, 20000);
-  test('create client token for custom store', async () => {
+  test('create client token for custom store already assigned to payment', async () => {
     const paymentRequest = {
       obj: {
         custom: {
           fields: {
             getClientTokenRequest: '{}',
             storeKey: paymentInStoreTestId,
+          },
+        },
+      },
+    } as unknown as PaymentReference;
+    await expectClientTokenRequest(paymentRequest);
+  }, 20000);
+  test('create client token for custom store that should be retrieved from the cart first', async () => {
+    const paymentRequest = {
+      obj: {
+        id: `${paymentInStoreTestId}-payment`,
+        custom: {
+          fields: {
+            getClientTokenRequest: '{}',
           },
         },
       },


### PR DESCRIPTION
This PR handles an issue if no fallback single tenant PayPal credentials were provided. The error occurred at getClientToken step, where payment had no store key assigned yet (the store key was previously assigned at createPayPal order step only). Therefore getClientToken tried to obtain single tenant key, didn't find the credentials and failed. When actually testing actually paying with PayPal it remained unnoticed, because createPayPal order already had access to relevant and was just obtaining a new relevant access token.