### PR TITLE
Feature/38922 tax mapping ct pay pal breakdown

### DIFF
--- a/paypal-commercetools-extension/package.json
+++ b/paypal-commercetools-extension/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@commercetools-backend/loggers": "^22.35.0",
-    "@commercetools/platform-sdk": "^7.22.0",
+    "@commercetools/platform-sdk": "^8.18.0",
     "@commercetools/sdk-client-v2": "^2.0.0",
     "@types/nodemailer": "^6.4.14",
     "axios": "^1.5.1",

--- a/paypal-commercetools-extension/src/service/commercetools.service.ts
+++ b/paypal-commercetools-extension/src/service/commercetools.service.ts
@@ -51,6 +51,7 @@ const getPaymentByPayPalOrderId = async (
 
   const results = payments.body.results;
   if (results.length !== 1) {
+    //more than 1 assigned order is prevented on commercetools side
     const detailedErrorMessage = `${paymentAction} action impossible - there is not any assigned commercetools payment for the PayPal order id ${orderId}`;
     logger.error(detailedErrorMessage);
     throw new CustomError(400, `Bad request: ${detailedErrorMessage}`);

--- a/paypal-commercetools-extension/src/service/payments.service.ts
+++ b/paypal-commercetools-extension/src/service/payments.service.ts
@@ -126,11 +126,6 @@ async function prepareCreateOrderRequest(
         '400',
         'For Pay Upon Invoice, the payment amount must exactly match the cart total gross amount if available and total price if total gross is not provided.'
       );
-    else if (cart.taxCalculationMode !== 'LineItemLevel')
-      throw new CustomError(
-        '422',
-        'For now only LineItemLevel tax mode is supported for Pay Upon Invoice due to mapping reasons.'
-      );
   }
   request = {
     intent:
@@ -166,9 +161,9 @@ async function prepareCreateOrderRequest(
           paymentSource?.experience_context?.shipping_preference !==
             'NO_SHIPPING' || !!cart.shippingAddress,
           cart.taxCalculationMode,
+          isPayUponInvoice,
           cart?.lineItems,
-          cart.locale,
-          isPayUponInvoice
+          cart.locale
         ),
       },
     ],
@@ -581,6 +576,7 @@ export const handleUpdateOrderRequest = async (
             true,
             !!cart.shippingAddress,
             cart.taxCalculationMode,
+            !!(payment.paymentMethodInfo.method === 'pay_upon_invoice'),
             cart?.lineItems,
             cart.locale
           ),

--- a/paypal-commercetools-extension/src/utils/map.utils.ts
+++ b/paypal-commercetools-extension/src/utils/map.utils.ts
@@ -158,7 +158,7 @@ const mapCommercetoolsLineItemsToPayPalItems = (
   locale?: string
 ) => {
   /*to avoid possible rounding issues if tax lead to fractional cent amounts in single commercetools line item price
-  mapping is done in a way: commercetools - item:socks, quantity:7; PayPal - item:socks (7), quantity:1 */
+  mapping is done in a way: commercetools - item:socks, quantity:7; PayPal - item:socks (x7), quantity:1 */
 
   const name = lineItem.name[locale ?? Object.keys(lineItem.name)[0]];
   const relevantPrice = isLineItemLevel
@@ -166,7 +166,7 @@ const mapCommercetoolsLineItemsToPayPalItems = (
     : lineItem.taxedPrice?.totalNet;
 
   const isSingleItem = lineItem.quantity === 1;
-  const relevantName = isSingleItem ? name : `${name} (${lineItem.quantity})`;
+  const relevantName = isSingleItem ? name : `${name} (x${lineItem.quantity})`;
   const relevantTotalItemPrice = relevantPrice
     ? relevantPrice.centAmount
     : lineItem.price.value.centAmount * lineItem.quantity;
@@ -189,10 +189,9 @@ const mapCommercetoolsLineItemsToPayPalItems = (
       currency_code: currencyCode,
     },
     sku: lineItem.variant.sku,
-    description:
-      lineItem.lineItemMode === 'GiftLineItem'
-        ? `${relevantName} gift item`
-        : relevantName,
+    description: `${
+      lineItem.lineItemMode === 'GiftLineItem' ? 'GIFT ITEM ' : ''
+    }${relevantName}`,
     category: isShipped ? 'PHYSICAL_GOODS' : 'DIGITAL_GOODS',
   };
 

--- a/paypal-commercetools-extension/src/utils/map.utils.ts
+++ b/paypal-commercetools-extension/src/utils/map.utils.ts
@@ -157,7 +157,6 @@ const mapCommercetoolsLineItemsToPayPalItems = (
   isPayUponInvoice: boolean,
   locale?: string
 ) => {
-  const taxOnItemLevelRequired = isPayUponInvoice && !isLineItemLevel;
   /*to avoid possible rounding issues if tax lead to fractional cent amounts in single commercetools line item price
   mapping is done in a way: commercetools - item:socks, quantity:7; PayPal - item:socks (7), quantity:1 */
 

--- a/paypal-commercetools-extension/src/utils/map.utils.ts
+++ b/paypal-commercetools-extension/src/utils/map.utils.ts
@@ -253,7 +253,7 @@ export const mapValidCommercetoolsLineItemsToPayPalItems = (
 export const mapCommercetoolsCartToPayPalPriceBreakdown = ({
   lineItems,
   discountOnTotalPrice,
-  taxedShippingPrice,
+  shippingInfo,
   taxCalculationMode,
 }: Cart) => {
   if (!lineItems || !lineItems[0]) {
@@ -297,7 +297,10 @@ export const mapCommercetoolsCartToPayPalPriceBreakdown = ({
     shipping: {
       currency_code: currencyCode,
       value: mapCommercetoolsMoneyToPayPalMoney({
-        centAmount: taxedShippingPrice?.totalGross?.centAmount ?? 0,
+        centAmount:
+          shippingInfo?.taxedPrice?.totalGross?.centAmount ??
+          shippingInfo?.price.centAmount ??
+          0, //in commercetools shipping discount is included in total discount and can't be easily separated - so amount before discount applied is used here
         fractionDigits,
         currencyCode,
         type,

--- a/paypal-commercetools-extension/src/utils/map.utils.ts
+++ b/paypal-commercetools-extension/src/utils/map.utils.ts
@@ -198,7 +198,7 @@ const mapCommercetoolsLineItemsToPayPalItems = (
       return {
         ...mappedItem,
         name: `${name} (${lineItem.quantity})`,
-        quantity: 1,
+        quantity: '1', //to avoid rounding mismatches we set quantity to 1 and adjust the unit amount to total line item price and tax to total line item tax, the quantity gets reflected in the name for PayPal side
         unit_amount: {
           value: mapCommercetoolsMoneyToPayPalMoney({
             centAmount:

--- a/paypal-commercetools-extension/tests/constants.ts
+++ b/paypal-commercetools-extension/tests/constants.ts
@@ -8,8 +8,65 @@ import {
   TaxedPrice,
   TaxRate,
 } from '@commercetools/platform-sdk';
+import { UpdateActions } from '../src/types/index.types';
+
+type PaymentStateMapData = [string, UpdateActions, boolean];
 
 type LineItemPropsImportantForMappingTests = Pick<
+export const dummyValidPaymentStatusData: Pick<
+  Payment,
+  'paymentStatus' | 'paymentMethodInfo'
+> = {
+  paymentStatus: { interfaceCode: 'code1', interfaceText: 'text1' },
+  paymentMethodInfo: { method: 'method1' },
+};
+
+const upToDateDummyActions = [
+  {
+    action: 'setMethodInfoMethod',
+    method: dummyValidPaymentStatusData.paymentMethodInfo.method,
+  },
+  {
+    action: 'setStatusInterfaceText',
+    interfaceText: dummyValidPaymentStatusData.paymentStatus.interfaceText,
+  },
+  {
+    action: 'setStatusInterfaceCode',
+    interfaceCode: dummyValidPaymentStatusData.paymentStatus.interfaceCode,
+  },
+];
+
+const dummyInvalidActionParams = {
+  method: 'different',
+  interfaceText: 'different',
+  interfaceCode: 'different',
+};
+
+export const paymentStateMappingWithResults: PaymentStateMapData[] = [
+  ['different amount of actions', [], false],
+  ...upToDateDummyActions.map(
+    ({ action }, index) =>
+      [
+        `action ${action} missing`,
+        upToDateDummyActions.map((item, index2) =>
+          index2 === index ? { action: 'irrelevant action' } : item
+        ),
+        false,
+      ] as PaymentStateMapData
+  ),
+  ...upToDateDummyActions.map(
+    ({ action }, index) =>
+      [
+        `action ${action} params differ from current payment`,
+        upToDateDummyActions.map((item, index2) =>
+          index2 === index ? { action, ...dummyInvalidActionParams } : item
+        ),
+        false,
+      ] as PaymentStateMapData
+  ),
+  ['up to date payment', upToDateDummyActions, true],
+];
+
   LineItem,
   'name' | 'lineItemMode' | 'quantity'
 > & {

--- a/paypal-commercetools-extension/tests/constants.ts
+++ b/paypal-commercetools-extension/tests/constants.ts
@@ -3,6 +3,8 @@ import {
   CentPrecisionMoney,
   DiscountOnTotalPrice,
   LineItem,
+  LineItemMode,
+  Payment,
   Price,
   ProductVariant,
   TaxedPrice,
@@ -68,30 +70,41 @@ export const paymentStateMappingWithResults: PaymentStateMapData[] = [
 
 type RelevantQuantityIndependentLineItemProps = Pick<
   LineItem,
-  'name' | 'lineItemMode' | 'quantity'
+  'name' | 'lineItemMode'
 > & {
   variant: Pick<ProductVariant, 'sku'>;
-  price: Pick<Price, 'value'>;
   taxRate?: Pick<TaxRate, 'amount'>;
+  price: Pick<Price, 'value'>;
 };
 
 type TaxedPricePropsImportantForMappingTests = Omit<TaxedPrice, 'taxPortions'>;
 
+type LineItemPropsImportantForMappingTests =
+  RelevantQuantityIndependentLineItemProps &
+    Pick<LineItem, 'quantity' | 'totalPrice'> & {
+      taxedPrice: TaxedPricePropsImportantForMappingTests;
+    };
+
 type CartPropsImportantForMappingTests = Pick<
   Cart,
   | 'totalPrice'
-  | 'discountOnTotalPrice'
   | 'taxCalculationMode'
   | 'taxMode'
   | 'taxRoundingMode'
   | 'priceRoundingMode'
   | 'directDiscounts'
   | 'discountCodes'
+  | 'locale'
 > & {
   lineItems: LineItemPropsImportantForMappingTests[];
   taxedPrice: TaxedPricePropsImportantForMappingTests;
-  taxedShippingPrice?: TaxedPricePropsImportantForMappingTests;
+  shippingInfo?: { taxedPrice: TaxedPricePropsImportantForMappingTests };
+  discountOnTotalPrice?: Omit<DiscountOnTotalPrice, 'includedDiscounts'>;
 };
+
+type PriceGenerationProps = { gross?: number; net?: number; tax?: number };
+
+type DiscountGenerationProps = { gross?: number; net?: number; amount: number };
 
 export const longTestTimeoutMs = 20000;
 
@@ -106,27 +119,21 @@ const centPrice = (centAmount = 0): CentPrecisionMoney => ({
   centAmount,
 });
 
-const taxedPrice = (
-  totalNet = 0,
-  totalGross = 0,
-  totalTax = 0
-): TaxedPricePropsImportantForMappingTests => ({
-  totalGross: centPrice(totalGross),
-  totalNet: centPrice(totalNet),
-  totalTax: centPrice(totalTax),
+const taxedPrice = ({
+  gross = 0,
+  net = 0,
+  tax = 0,
+}: PriceGenerationProps): TaxedPricePropsImportantForMappingTests => ({
+  totalGross: centPrice(gross),
+  totalNet: centPrice(net),
+  totalTax: centPrice(tax),
 });
 
 const DEFAULT_EU_TAX_RATE = 0.19;
 
-export const fullPriceData = (
-  totalNet = 0,
-  totalGross = 0,
-  totalTax = 0,
-  taxRate = DEFAULT_EU_TAX_RATE
-) => ({
-  taxedPrice: taxedPrice(totalNet, totalGross, totalTax),
-  totalPrice: centPrice(totalGross),
-  taxRate: { amount: taxRate },
+export const fullPriceData = (priceData: PriceGenerationProps) => ({
+  taxedPrice: taxedPrice(priceData),
+  totalPrice: centPrice(priceData.gross ?? 0),
 });
 
 const giftLineItem: LineItemPropsImportantForMappingTests = {
@@ -141,7 +148,7 @@ const giftLineItem: LineItemPropsImportantForMappingTests = {
   },
   quantity: 1,
   lineItemMode: 'GiftLineItem',
-  ...fullPriceData(),
+  ...fullPriceData({}),
 };
 
 export const discountedLineitemWithTaxIncluded: LineItemPropsImportantForMappingTests =
@@ -152,7 +159,7 @@ export const discountedLineitemWithTaxIncluded: LineItemPropsImportantForMapping
     },
     quantity: 1,
     lineItemMode: 'Standard',
-    ...fullPriceData(16723, 19900, 3177),
+    ...fullPriceData({ gross: 19900, net: 16723, tax: 3177 }),
   };
 
 export const discountedLineItems = [
@@ -160,15 +167,14 @@ export const discountedLineItems = [
   discountedLineitemWithTaxIncluded,
 ];
 
-export const discountOnTotalPrice = (
-  discountedAmount: number,
-  discountedNetAmount: number,
-  discountedGrossAmount: number
-): DiscountOnTotalPrice => ({
-  discountedAmount: centPrice(discountedAmount),
-  includedDiscounts: [], //details about discounts are not required for mapping
-  discountedNetAmount: centPrice(discountedNetAmount),
-  discountedGrossAmount: centPrice(discountedGrossAmount),
+export const discountOnTotalPrice = ({
+  gross,
+  net,
+  amount,
+}: DiscountGenerationProps) => ({
+  discountedAmount: centPrice(amount),
+  discountedNetAmount: net ? centPrice(net) : undefined,
+  discountedGrossAmount: gross ? centPrice(gross) : undefined,
 });
 
 const defaultRelevantForMappingCTCartParams = {
@@ -178,6 +184,7 @@ const defaultRelevantForMappingCTCartParams = {
   taxMode: 'Platform',
   taxRoundingMode: 'HalfEven',
   taxCalculationMode: 'LineItemLevel',
+  locale: 'de',
 };
 
 export const cartWithExternalRate: CartPropsImportantForMappingTests = {
@@ -195,7 +202,7 @@ export const cartWithExternalRate: CartPropsImportantForMappingTests = {
       },
       quantity: 1,
       lineItemMode: 'Standard',
-      ...fullPriceData(15629, 18599, 2970),
+      ...fullPriceData({ gross: 18599, net: 15629, tax: 2970 }),
     },
     {
       name: {
@@ -209,12 +216,16 @@ export const cartWithExternalRate: CartPropsImportantForMappingTests = {
       },
       quantity: 1,
       lineItemMode: 'Standard',
-      ...fullPriceData(18599, 22133, 3534),
+      ...fullPriceData({ gross: 22133, net: 18599, tax: 3534 }),
     },
   ],
-  ...fullPriceData(29778, 35437, 5659),
-  taxedShippingPrice: taxedPrice(),
-  discountOnTotalPrice: discountOnTotalPrice(4836, 4450, 5295),
+  ...fullPriceData({ gross: 35437, net: 29778, tax: 5659 }),
+  shippingInfo: { taxedPrice: taxedPrice({}) },
+  discountOnTotalPrice: discountOnTotalPrice({
+    gross: 5295,
+    net: 4836,
+    amount: 4450,
+  }),
 };
 
 export const multipleItemsCartWithUnitPriceTaxMode: CartPropsImportantForMappingTests =
@@ -233,10 +244,298 @@ export const multipleItemsCartWithUnitPriceTaxMode: CartPropsImportantForMapping
         },
         quantity: 3,
         lineItemMode: 'Standard',
-        ...fullPriceData(46887, 55797, 8910),
+        ...fullPriceData({ gross: 55797, net: 46887, tax: 8910 }),
       },
     ],
-    ...fullPriceData(40791, 48543, 7752),
-    discountOnTotalPrice: discountOnTotalPrice(7254, 6096, 7254),
+    ...fullPriceData({ gross: 48543, net: 40791, tax: 7752 }),
+    discountOnTotalPrice: discountOnTotalPrice({
+      gross: 7254,
+      net: 6096,
+      amount: 7254,
+    }),
     taxCalculationMode: 'UnitPriceLevel',
   };
+
+const generateLineItemProps = (
+  referenceName: string,
+  itemPrice: number,
+  lineItemMode?: LineItemMode,
+  taxRate = DEFAULT_EU_TAX_RATE
+): RelevantQuantityIndependentLineItemProps => ({
+  name: {
+    en: `name${referenceName}`,
+  },
+  variant: { sku: `sku${referenceName}` },
+  taxRate: { amount: taxRate },
+  lineItemMode: lineItemMode ?? 'Standard',
+  price: { value: centPrice(itemPrice) },
+});
+
+const testLineItemsBaseData = {
+  //all test data are based on sandbox products, corresponding product can be found by name
+  defaultItem: { ...generateLineItemProps('amanda gray', 22375) }, // default ct item type, included standard EU tax, no discounts
+  doubleDiscountedItemWithGift: {
+    ...generateLineItemProps('amanda brown', 23134), // this item forces the cart to get total discount
+  },
+  productDiscountItem: {
+    ...generateLineItemProps('amanda black', 24376), //product discount is already included in product price and doesn't need to be mapped for PayPal separately
+  },
+  taxNotIncludedInBasePrice: {
+    ...generateLineItemProps('amanda red', 19999), //tax is still included in total gross, so it influences only rounding on ct side
+  },
+};
+
+export type LineItemGenerationData = PriceGenerationProps & {
+  itemType: keyof typeof testLineItemsBaseData;
+  quantity: number;
+  lineItemMode?: LineItemMode;
+};
+
+type CartGenerationData = {
+  lineItemsData: LineItemGenerationData[];
+  cardPrice?: PriceGenerationProps;
+  discount?: DiscountGenerationProps;
+  customCardProps?: Partial<CartPropsImportantForMappingTests>;
+};
+
+export const lineItemFromLineItemData = ({
+  itemType,
+  quantity,
+  gross,
+  net,
+  tax,
+  lineItemMode,
+}: LineItemGenerationData) => ({
+  ...testLineItemsBaseData[itemType],
+  lineItemMode: lineItemMode ?? 'Standard',
+  quantity: quantity,
+  ...fullPriceData({ gross, net, tax }),
+});
+
+export const cardFromCardData = ({
+  lineItemsData,
+  cardPrice,
+  discount,
+  customCardProps = {},
+}: CartGenerationData) => ({
+  ...defaultRelevantForMappingCTCartParams,
+  lineItems: lineItemsData.map(lineItemFromLineItemData),
+  ...fullPriceData(cardPrice ?? lineItemsData[0]),
+  discountOnTotalPrice: discount ? discountOnTotalPrice(discount) : undefined,
+  ...customCardProps,
+});
+
+const giftLineItemData: LineItemGenerationData = {
+  gross: 0,
+  net: 0,
+  tax: 0,
+  itemType: 'doubleDiscountedItemWithGift',
+  quantity: 1,
+  lineItemMode: 'GiftLineItem',
+};
+
+export const simpleCartsDataWithLineItemMode: CartGenerationData[] = [
+  //"magic" numbers are extracted from sandbox commercetools products and cards
+  {
+    lineItemsData: [
+      {
+        gross: 22375,
+        net: 18803,
+        tax: 3572,
+        itemType: 'defaultItem',
+        quantity: 1,
+      },
+    ],
+  },
+  {
+    lineItemsData: [
+      {
+        gross: 44750,
+        net: 37605,
+        tax: 7145,
+        itemType: 'defaultItem',
+        quantity: 2,
+      },
+    ],
+  },
+  {
+    lineItemsData: [
+      {
+        gross: 67125,
+        net: 56408,
+        tax: 10717,
+        itemType: 'defaultItem',
+        quantity: 3,
+      },
+    ],
+  },
+  {
+    lineItemsData: [
+      {
+        gross: 24376,
+        net: 20484,
+        tax: 3892,
+        itemType: 'productDiscountItem',
+        quantity: 1,
+      },
+    ],
+  },
+  {
+    lineItemsData: [
+      {
+        gross: 48752,
+        net: 40968,
+        tax: 7784,
+        itemType: 'productDiscountItem',
+        quantity: 2,
+      },
+    ],
+  },
+  {
+    lineItemsData: [
+      {
+        gross: 73128,
+        net: 61452,
+        tax: 11676,
+        itemType: 'productDiscountItem',
+        quantity: 3,
+      },
+    ],
+  },
+  {
+    lineItemsData: [
+      {
+        gross: 27529,
+        net: 23134,
+        tax: 4395,
+        itemType: 'taxNotIncludedInBasePrice',
+        quantity: 1,
+      },
+    ],
+  },
+  {
+    lineItemsData: [
+      {
+        gross: 55059,
+        net: 46268,
+        tax: 8791,
+        itemType: 'taxNotIncludedInBasePrice',
+        quantity: 2,
+      },
+    ],
+  },
+
+  {
+    lineItemsData: [
+      {
+        gross: 82588,
+        net: 69402,
+        tax: 13186,
+        itemType: 'taxNotIncludedInBasePrice',
+        quantity: 3,
+      },
+    ],
+  },
+];
+
+export const simpleCartsDataWithUnitPriceMode: CartGenerationData[] = [
+  {
+    customCardProps: { taxCalculationMode: 'UnitPriceLevel' },
+    lineItemsData: [
+      {
+        gross: 55058,
+        net: 46268,
+        tax: 8790,
+        itemType: 'taxNotIncludedInBasePrice',
+        quantity: 2,
+      },
+    ],
+  },
+  {
+    customCardProps: { taxCalculationMode: 'UnitPriceLevel' },
+    lineItemsData: [
+      {
+        gross: 82587,
+        net: 69402,
+        tax: 13185,
+        itemType: 'taxNotIncludedInBasePrice',
+        quantity: 3,
+      },
+    ],
+  },
+];
+
+export const discountedCartsData: CartGenerationData[] = [
+  {
+    lineItemsData: [
+      {
+        gross: 23134,
+        net: 19440,
+        tax: 3694,
+        itemType: 'doubleDiscountedItemWithGift',
+        quantity: 1,
+      },
+      giftLineItemData,
+    ],
+    cardPrice: { gross: 20127, net: 16913, tax: 3214 },
+    discount: { gross: 3007, net: 2527, amount: 3007 },
+  },
+  {
+    lineItemsData: [
+      {
+        gross: 46268,
+        net: 38881,
+        tax: 7387,
+        itemType: 'doubleDiscountedItemWithGift',
+        quantity: 2,
+      },
+      giftLineItemData,
+    ],
+    cardPrice: { gross: 40253, net: 33826, tax: 6427 },
+    discount: { gross: 6015, net: 5055, amount: 6015 },
+  },
+  {
+    lineItemsData: [
+      {
+        gross: 69402,
+        net: 58321,
+        tax: 11081,
+        itemType: 'doubleDiscountedItemWithGift',
+        quantity: 3,
+      },
+      giftLineItemData,
+    ],
+    cardPrice: { gross: 60380, net: 50739, tax: 9641 },
+    discount: { gross: 9022, net: 7582, amount: 9022 },
+  },
+];
+
+export const shippedCarts: CartGenerationData[] = [
+  {
+    lineItemsData: [
+      {
+        itemType: 'doubleDiscountedItemWithGift',
+        quantity: 1,
+        gross: 23134,
+        net: 19440,
+        tax: 3694,
+      },
+      giftLineItemData,
+      {
+        itemType: 'taxNotIncludedInBasePrice',
+        quantity: 3,
+        gross: 82587,
+        net: 69402,
+        tax: 13185,
+      },
+    ],
+    cardPrice: { net: 78023, gross: 92847, tax: 14824 },
+    discount: { net: 11659, gross: 13874, amount: 12160 },
+    customCardProps: {
+      shippingInfo: {
+        taxedPrice: taxedPrice({ gross: 1000, net: 840, tax: 160 }),
+      },
+      taxCalculationMode: 'UnitPriceLevel',
+    },
+  },
+];

--- a/paypal-commercetools-extension/tests/constants.ts
+++ b/paypal-commercetools-extension/tests/constants.ts
@@ -1,9 +1,36 @@
 import {
   Cart,
   CentPrecisionMoney,
+  DiscountOnTotalPrice,
   LineItem,
-  ProductDiscountReference,
+  Price,
+  ProductVariant,
+  TaxedItemPrice,
+  TaxRate,
 } from '@commercetools/platform-sdk';
+
+type LineItemPropsImportantForMappingTests = Pick<
+  LineItem,
+  'name' | 'lineItemMode' | 'quantity'
+> & {
+  variant: Pick<ProductVariant, 'sku'>;
+} & { price: Pick<Price, 'value'> } & {
+  taxRate?: Pick<TaxRate, 'amount'>;
+};
+
+type CartPropsImportantForMappingTests = Pick<
+  Cart,
+  | 'totalPrice'
+  | 'taxedPrice'
+  | 'discountOnTotalPrice'
+  | 'taxCalculationMode'
+  | 'taxMode'
+  | 'taxRoundingMode'
+  | 'priceRoundingMode'
+  | 'directDiscounts'
+  | 'taxedShippingPrice'
+  | 'discountCodes'
+> & { lineItems: LineItemPropsImportantForMappingTests[] };
 
 export const longTestTimeoutMs = 20000;
 
@@ -13,711 +40,144 @@ const currencyData: Omit<CentPrecisionMoney, 'centAmount'> = {
   fractionDigits: 2,
 };
 
-const taxedPrice = {
-  totalNet: {
-    ...currencyData,
-    centAmount: 16303,
-  },
-  totalGross: {
-    ...currencyData,
-    centAmount: 19400,
-  },
-  totalTax: {
-    ...currencyData,
-    centAmount: 3097,
-  },
-};
-
-export const prices = {
-  totalPrice: {
-    ...currencyData,
-    centAmount: 19400,
-  },
-  taxedPrice,
-};
-
-const total0: CentPrecisionMoney = {
+const centPrice = (centAmount = 0): CentPrecisionMoney => ({
   ...currencyData,
-  centAmount: 0,
-};
+  centAmount,
+});
 
-const total5Eur = {
-  ...currencyData,
-  centAmount: 500,
-};
+const taxedPrice = (
+  totalNet = 0,
+  totalGross = 0,
+  totalTax = 0
+): TaxedItemPrice => ({
+  totalGross: centPrice(totalGross),
+  totalNet: centPrice(totalNet),
+  totalTax: centPrice(totalTax),
+  taxPortions: [],
+});
 
-const discountProductPercent: ProductDiscountReference = {
-  typeId: 'product-discount',
-  id: 'b63ef66f-809f-4959-b72b-7cb449cfc259',
-};
+const fullPriceData = (
+  totalNet = 0,
+  totalGross = 0,
+  totalTax = 0,
+  taxRateAmount = 0.19
+) => ({
+  taxedPrice: taxedPrice(totalNet, totalGross, totalTax),
+  totalPrice: centPrice(totalGross),
+  taxRate: { amount: taxRateAmount },
+});
 
-type LineItemWithoutPriceDetails = Omit<
-  LineItem,
-  | 'price'
-  | 'id'
-  | 'quantity'
-  | 'totalPrice'
-  | 'discountedPricePerQuantity'
-  | 'taxedPricePortions'
-  | 'lineItemMode'
->;
+export const prices = fullPriceData(16303, 19400, 3097);
 
-const discountedProductWithTaxIncluded: LineItemWithoutPriceDetails = {
-  productId: '47708631-7f05-4881-8d9b-9563c567f1e3',
-  productKey: '80736',
+const giftLineItem: LineItemPropsImportantForMappingTests = {
   name: {
     en: 'Bag ”Amanda B” Liebeskind brown',
-    de: 'Tasche „Amanda B” Liebeskind braun',
-  },
-  productType: {
-    typeId: 'product-type',
-    id: '5caccab5-9af3-461f-9643-ee5870e9ea10',
-  },
-  productSlug: {
-    en: 'liebeskind-bag-amanda-b-brown',
-    de: 'liebeskind-tasche-amanda-b-braun',
   },
   variant: {
-    id: 1,
     sku: 'A0E2000000024BC',
-    key: 'A0E2000000024BC',
   },
-  taxRate: {
-    name: '19% incl.',
-    amount: 0.19,
-    includedInPrice: true,
-    country: 'DE',
-    id: 'ztfE6U8r',
-    subRates: [],
-  },
-  perMethodTaxRate: [],
-  addedAt: '2024-12-05T13:45:51.792Z',
-  lastModifiedAt: '2024-12-05T13:45:51.792Z',
-  state: [
-    {
-      quantity: 1,
-      state: {
-        typeId: 'state',
-        id: '7a8d376f-4298-48ca-b442-df93bae0978e',
-      },
-    },
-  ],
-  priceMode: 'Platform',
-};
-
-const giftLineItem: LineItem = {
-  id: '45e9ee9f-9d6b-4e01-934b-b794cc303995',
-  ...discountedProductWithTaxIncluded,
   price: {
-    id: '3a828cda-165c-4a67-b610-19cb8339fe98',
-    value: {
-      type: 'centPrecision',
-      currencyCode: 'EUR',
-      centAmount: 24875,
-      fractionDigits: 2,
-    },
-    discounted: {
-      value: {
-        type: 'centPrecision',
-        currencyCode: 'EUR',
-        centAmount: 19900,
-        fractionDigits: 2,
-      },
-      discount: {
-        typeId: 'product-discount',
-        id: 'b63ef66f-809f-4959-b72b-7cb449cfc259',
-      },
-    },
+    value: centPrice(24875),
   },
   quantity: 1,
-  discountedPricePerQuantity: [
-    {
-      quantity: 1,
-      discountedPrice: {
-        value: total0,
-        includedDiscounts: [
-          {
-            discount: {
-              typeId: 'cart-discount',
-              id: '9d8110ff-037b-4c5a-b7ec-cce61dd6f598',
-            },
-            discountedAmount: {
-              type: 'centPrecision',
-              currencyCode: 'EUR',
-              centAmount: 19900,
-              fractionDigits: 2,
-            },
-          },
-        ],
-      },
-    },
-  ],
   lineItemMode: 'GiftLineItem',
-  totalPrice: total0,
-  taxedPrice: {
-    totalNet: total0,
-    totalGross: total0,
-    taxPortions: [
-      {
-        rate: 0.19,
-        amount: total0,
-        name: '19% incl.',
-      },
-    ],
-    totalTax: total0,
-  },
-  taxedPricePortions: [],
+  ...fullPriceData(),
 };
 
-export const discountedLineitemWithTaxIncluded: LineItem = {
-  id: 'cfb73a1a-3884-4e01-b435-dce4c5ebea79',
-  ...discountedProductWithTaxIncluded,
-  price: {
-    id: '3a828cda-165c-4a67-b610-19cb8339fe98',
-    value: {
-      type: 'centPrecision',
-      currencyCode: 'EUR',
-      centAmount: 24875,
-      fractionDigits: 2,
+export const discountedLineitemWithTaxIncluded: LineItemPropsImportantForMappingTests =
+  {
+    ...giftLineItem,
+    price: {
+      value: centPrice(24875),
     },
-    discounted: {
-      value: {
-        type: 'centPrecision',
-        currencyCode: 'EUR',
-        centAmount: 19900,
-        fractionDigits: 2,
-      },
-      discount: discountProductPercent,
-    },
-  },
-  quantity: 1,
-  discountedPricePerQuantity: [],
-  lineItemMode: 'Standard',
-  totalPrice: {
-    type: 'centPrecision',
-    currencyCode: 'EUR',
-    centAmount: 19900,
-    fractionDigits: 2,
-  },
-  taxedPrice: {
-    totalNet: {
-      type: 'centPrecision',
-      currencyCode: 'EUR',
-      centAmount: 16723,
-      fractionDigits: 2,
-    },
-    totalGross: {
-      type: 'centPrecision',
-      currencyCode: 'EUR',
-      centAmount: 19900,
-      fractionDigits: 2,
-    },
-    taxPortions: [
-      {
-        rate: 0.19,
-        amount: {
-          type: 'centPrecision',
-          currencyCode: 'EUR',
-          centAmount: 3177,
-          fractionDigits: 2,
-        },
-        name: '19% incl.',
-      },
-    ],
-    totalTax: {
-      type: 'centPrecision',
-      currencyCode: 'EUR',
-      centAmount: 3177,
-      fractionDigits: 2,
-    },
-  },
-  taxedPricePortions: [],
-};
+    quantity: 1,
+    lineItemMode: 'Standard',
+    ...fullPriceData(16723, 19900, 3177),
+  };
 
-export const discountedLineItems: LineItem[] = [
+export const discountedLineItems = [
   giftLineItem,
   discountedLineitemWithTaxIncluded,
 ];
 
-export const discountOnTotalPrice = {
-  discountedAmount: total5Eur,
-  includedDiscounts: [
-    {
-      discount: {
-        typeId: 'cart-discount',
-        id: 'c4b96843-e2ae-4c3c-987e-7c9819a13a40',
-      },
-      discountedAmount: total5Eur,
-    },
-  ],
-  discountedNetAmount: {
-    type: 'centPrecision',
-    currencyCode: 'EUR',
-    centAmount: 420,
-    fractionDigits: 2,
-  },
-  discountedGrossAmount: total5Eur,
+export const discountOnTotalPrice = (
+  discountedAmount: number,
+  discountedNetAmount: number,
+  discountedGrossAmount: number
+): DiscountOnTotalPrice => ({
+  discountedAmount: centPrice(discountedAmount),
+  includedDiscounts: [], //details about discounts are not required for mapping
+  discountedNetAmount: centPrice(discountedNetAmount),
+  discountedGrossAmount: centPrice(discountedGrossAmount),
+});
+
+const defaultRelevantForMappingCTCartParams = {
+  priceRoundingMode: 'HalfEven',
+  discountCodes: [],
+  directDiscounts: [],
+  taxMode: 'Platform',
+  taxRoundingMode: 'HalfEven',
+  taxCalculationMode: 'LineItemLevel',
 };
 
-export const cartWithExternalRate: Cart = {
-  id: '0d675b6f-e026-4ff8-aa4f-69a7308d4a26',
-  version: 270,
-  createdAt: '2025-02-13T12:03:53.423Z',
-  lastModifiedAt: '2025-02-17T10:09:40.474Z',
-  lastModifiedBy: {
-    clientId: 'seJiutIQQgFYw_vafgdcXCt5',
-  },
-  createdBy: { clientId: 'seJiutIQQgFYw_vafgdcXCt5' },
-  customerEmail: 'asd@df.asd',
-  anonymousId: '93d87ba5-01ea-4b30-04e3-599ef868cc59',
-  locale: 'en',
+export const cartWithExternalRate: CartPropsImportantForMappingTests = {
+  ...defaultRelevantForMappingCTCartParams,
   lineItems: [
     {
-      id: 'fca9f426-8d97-4168-87df-63886abfbcb8',
-      productId: '47708631-7f05-4881-8d9b-9563c567f1e3',
-      productKey: '80736',
       name: {
         en: 'Bag ”Amanda B” Liebeskind brown',
-        de: 'Tasche „Amanda B” Liebeskind braun',
-      },
-      productType: {
-        typeId: 'product-type',
-        id: '5caccab5-9af3-461f-9643-ee5870e9ea10',
-      },
-      productSlug: {
-        en: 'liebeskind-bag-amanda-b-brown',
-        de: 'liebeskind-tasche-amanda-b-braun',
       },
       variant: {
-        id: 1,
         sku: 'A0E2000000024BC',
-        key: 'A0E2000000024BC',
       },
       price: {
-        id: '0d623977-dc7e-4e16-9690-dea4121274ee',
-        value: {
-          type: 'centPrecision',
-          currencyCode: 'EUR',
-          centAmount: 19999,
-          fractionDigits: 2,
-        },
-        country: 'DE',
-        discounted: {
-          value: {
-            type: 'centPrecision',
-            currencyCode: 'EUR',
-            centAmount: 18599,
-            fractionDigits: 2,
-          },
-          discount: discountProductPercent,
-        },
+        value: centPrice(19999),
       },
       quantity: 1,
-      discountedPricePerQuantity: [],
-      taxRate: {
-        name: '19% incl.',
-        amount: 0.19,
-        includedInPrice: true,
-        country: 'DE',
-        id: 'ztfE6U8r',
-        subRates: [],
-      },
-      perMethodTaxRate: [],
-      addedAt: '2025-02-13T14:06:31.109Z',
-      lastModifiedAt: '2025-02-13T14:06:31.109Z',
-      state: [
-        {
-          quantity: 1,
-          state: {
-            typeId: 'state',
-            id: '7a8d376f-4298-48ca-b442-df93bae0978e',
-          },
-        },
-      ],
-      priceMode: 'Platform',
       lineItemMode: 'Standard',
-      totalPrice: {
-        type: 'centPrecision',
-        currencyCode: 'EUR',
-        centAmount: 18599,
-        fractionDigits: 2,
-      },
-      taxedPrice: {
-        totalNet: {
-          type: 'centPrecision',
-          currencyCode: 'EUR',
-          centAmount: 15629,
-          fractionDigits: 2,
-        },
-        totalGross: {
-          type: 'centPrecision',
-          currencyCode: 'EUR',
-          centAmount: 18599,
-          fractionDigits: 2,
-        },
-        taxPortions: [
-          {
-            rate: 0.19,
-            amount: {
-              type: 'centPrecision',
-              currencyCode: 'EUR',
-              centAmount: 2970,
-              fractionDigits: 2,
-            },
-            name: '19% incl.',
-          },
-        ],
-        totalTax: {
-          type: 'centPrecision',
-          currencyCode: 'EUR',
-          centAmount: 2970,
-          fractionDigits: 2,
-        },
-      },
-      taxedPricePortions: [],
+      ...fullPriceData(15629, 18599, 2970),
     },
     {
-      id: '700c548d-7300-4d04-86d8-e7208a469b55',
-      productId: 'bf14fc2e-4e39-435d-a213-36a424540eb6',
-      productKey: '80737',
       name: {
         en: 'Bag ”Amanda B” Liebeskind red',
         de: 'Tasche „Amanda B” Liebeskind rot',
       },
-      productType: {
-        typeId: 'product-type',
-        id: '5caccab5-9af3-461f-9643-ee5870e9ea10',
-      },
-      productSlug: {
-        en: 'liebeskind-bag-amanda-b-red',
-        de: 'liebeskind-tasche-amanda-b-rot',
-      },
       variant: {
-        id: 1,
         sku: 'A0E2000000024BD',
-        key: 'A0E2000000024BD',
       },
       price: {
-        id: '8f4d5f07-6a94-4f9f-b578-697463d42078',
-        value: {
-          type: 'centPrecision',
-          currencyCode: 'EUR',
-          centAmount: 19999,
-          fractionDigits: 2,
-        },
-        country: 'DE',
-        discounted: {
-          value: {
-            type: 'centPrecision',
-            currencyCode: 'EUR',
-            centAmount: 18599,
-            fractionDigits: 2,
-          },
-          discount: {
-            typeId: 'product-discount',
-            id: 'aef33a28-eb9a-46e8-b68b-7fc1c6d01830',
-          },
-        },
+        value: centPrice(19999),
       },
       quantity: 1,
-      discountedPricePerQuantity: [],
-      taxRate: {
-        name: 'not-in-price-tax-category',
-        amount: 0.19,
-        includedInPrice: false,
-        country: 'DE',
-        id: 'qcBEaLs2',
-        subRates: [],
-      },
-      perMethodTaxRate: [],
-      addedAt: '2025-02-13T14:24:30.523Z',
-      lastModifiedAt: '2025-02-13T14:24:30.523Z',
-      state: [
-        {
-          quantity: 1,
-          state: {
-            typeId: 'state',
-            id: '7a8d376f-4298-48ca-b442-df93bae0978e',
-          },
-        },
-      ],
-      priceMode: 'Platform',
       lineItemMode: 'Standard',
-      totalPrice: {
-        type: 'centPrecision',
-        currencyCode: 'EUR',
-        centAmount: 18599,
-        fractionDigits: 2,
-      },
-      taxedPrice: {
-        totalNet: {
-          type: 'centPrecision',
-          currencyCode: 'EUR',
-          centAmount: 18599,
-          fractionDigits: 2,
-        },
-        totalGross: {
-          type: 'centPrecision',
-          currencyCode: 'EUR',
-          centAmount: 22133,
-          fractionDigits: 2,
-        },
-        taxPortions: [
-          {
-            rate: 0.19,
-            amount: {
-              type: 'centPrecision',
-              currencyCode: 'EUR',
-              centAmount: 3534,
-              fractionDigits: 2,
-            },
-            name: 'not-in-price-tax-category',
-          },
-        ],
-        totalTax: {
-          type: 'centPrecision',
-          currencyCode: 'EUR',
-          centAmount: 3534,
-          fractionDigits: 2,
-        },
-      },
-      taxedPricePortions: [],
+      ...fullPriceData(18599, 22133, 3534),
     },
   ],
-  cartState: 'Active',
-  totalPrice: {
-    type: 'centPrecision',
-    currencyCode: 'EUR',
-    centAmount: 32362,
-    fractionDigits: 2,
-  },
-  taxedPrice: {
-    totalNet: {
-      type: 'centPrecision',
-      currencyCode: 'EUR',
-      centAmount: 29778,
-      fractionDigits: 2,
-    },
-    totalGross: {
-      type: 'centPrecision',
-      currencyCode: 'EUR',
-      centAmount: 35437,
-      fractionDigits: 2,
-    },
-    taxPortions: [
-      {
-        rate: 0.19,
-        amount: {
-          type: 'centPrecision',
-          currencyCode: 'EUR',
-          centAmount: 2970,
-          fractionDigits: 2,
-        },
-        name: '19% incl.',
-      },
-      {
-        rate: 0.19,
-        amount: {
-          type: 'centPrecision',
-          currencyCode: 'EUR',
-          centAmount: 3534,
-          fractionDigits: 2,
-        },
-        name: 'not-in-price-tax-category',
-      },
-    ],
-    totalTax: {
-      type: 'centPrecision',
-      currencyCode: 'EUR',
-      centAmount: 5659,
-      fractionDigits: 2,
-    },
-  },
-  country: 'DE',
-  taxedShippingPrice: {
-    totalNet: {
-      type: 'centPrecision',
-      currencyCode: 'EUR',
-      centAmount: 0,
-      fractionDigits: 2,
-    },
-    totalGross: {
-      type: 'centPrecision',
-      currencyCode: 'EUR',
-      centAmount: 0,
-      fractionDigits: 2,
-    },
-    taxPortions: [
-      {
-        rate: 0.19,
-        amount: {
-          type: 'centPrecision',
-          currencyCode: 'EUR',
-          centAmount: 0,
-          fractionDigits: 2,
-        },
-        name: '19% incl.',
-      },
-    ],
-    totalTax: {
-      type: 'centPrecision',
-      currencyCode: 'EUR',
-      centAmount: 0,
-      fractionDigits: 2,
-    },
-  },
-  discountOnTotalPrice: {
-    discountedAmount: {
-      type: 'centPrecision',
-      currencyCode: 'EUR',
-      centAmount: 4836,
-      fractionDigits: 2,
-    },
-    includedDiscounts: [
-      {
-        discount: {
-          typeId: 'cart-discount',
-          id: 'c4b96843-e2ae-4c3c-987e-7c9819a13a40',
-        },
-        discountedAmount: {
-          type: 'centPrecision',
-          currencyCode: 'EUR',
-          centAmount: 4836,
-          fractionDigits: 2,
-        },
-      },
-    ],
-    discountedNetAmount: {
-      type: 'centPrecision',
-      currencyCode: 'EUR',
-      centAmount: 4450,
-      fractionDigits: 2,
-    },
-    discountedGrossAmount: {
-      type: 'centPrecision',
-      currencyCode: 'EUR',
-      centAmount: 5295,
-      fractionDigits: 2,
-    },
-  },
-  shippingMode: 'Single',
-  shippingInfo: {
-    shippingMethodName: 'Standard EU',
-    price: {
-      type: 'centPrecision',
-      currencyCode: 'EUR',
-      centAmount: 0,
-      fractionDigits: 2,
-    },
-    shippingRate: {
-      price: {
-        type: 'centPrecision',
-        currencyCode: 'EUR',
-        centAmount: 0,
-        fractionDigits: 2,
-      },
-      freeAbove: {
-        type: 'centPrecision',
-        currencyCode: 'EUR',
-        centAmount: 20000,
-        fractionDigits: 2,
-      },
-      tiers: [],
-    },
-    taxRate: {
-      name: '19% incl.',
-      amount: 0.19,
-      includedInPrice: true,
-      country: 'DE',
-      id: 'ztfE6U8r',
-      subRates: [],
-    },
-    taxCategory: {
-      typeId: 'tax-category',
-      id: 'e10f3742-c379-4a27-be01-6529676bd542',
-    },
-    deliveries: [],
-    shippingMethod: {
-      typeId: 'shipping-method',
-      id: '5eae0359-c347-4d51-b4ae-fba64a7d8221',
-    },
-    taxedPrice: {
-      totalNet: {
-        type: 'centPrecision',
-        currencyCode: 'EUR',
-        centAmount: 0,
-        fractionDigits: 2,
-      },
-      totalGross: {
-        type: 'centPrecision',
-        currencyCode: 'EUR',
-        centAmount: 0,
-        fractionDigits: 2,
-      },
-      taxPortions: [
-        {
-          rate: 0.19,
-          amount: {
-            type: 'centPrecision',
-            currencyCode: 'EUR',
-            centAmount: 0,
-            fractionDigits: 2,
-          },
-          name: '19% incl.',
-        },
-      ],
-      totalTax: {
-        type: 'centPrecision',
-        currencyCode: 'EUR',
-        centAmount: 0,
-        fractionDigits: 2,
-      },
-    },
-    shippingMethodState: 'MatchesCart',
-  },
-  shippingAddress: {
-    firstName: 'sad',
-    lastName: 'asd',
-    streetName: 'asd',
-    streetNumber: 'asd',
-    postalCode: '12345',
-    city: 'asd',
-    country: 'DE',
-  },
-  shipping: [],
-  customLineItems: [],
-  discountCodes: [],
-  directDiscounts: [],
-  paymentInfo: {
-    payments: [
-      { typeId: 'payment', id: 'd11c67e1-721d-4d95-a7c0-18f151cf4217' },
-      { typeId: 'payment', id: '51f0b602-d4f2-4faf-a8c9-33b9900702f4' },
-      { typeId: 'payment', id: '5c286d43-4760-4bd9-a76d-537b4eb792cc' },
-      { typeId: 'payment', id: '175b6cb7-e469-4053-9bd4-40a397417a52' },
-      { typeId: 'payment', id: 'bd374bda-999d-43a8-be0a-8e39694e3a85' },
-      { typeId: 'payment', id: 'a5a0ebcd-7c65-432e-a438-15a71d35e552' },
-      { typeId: 'payment', id: '1990ad61-079d-4990-8cca-9eda9bf47dea' },
-      { typeId: 'payment', id: '70583c70-cec6-40e5-b882-f1656b73f23a' },
-    ],
-  },
-  inventoryMode: 'ReserveOnOrder',
-  taxMode: 'Platform',
-  taxRoundingMode: 'HalfEven',
-  taxCalculationMode: 'LineItemLevel',
-  deleteDaysAfterLastModification: 90,
-  refusedGifts: [
-    { typeId: 'cart-discount', id: '9d8110ff-037b-4c5a-b7ec-cce61dd6f598' },
-  ],
-  origin: 'Customer',
-  billingAddress: {
-    firstName: 'sad',
-    lastName: 'asd',
-    streetName: 'asd',
-    streetNumber: 'asd',
-    postalCode: '12345',
-    city: 'asd',
-    country: 'DE',
-  },
-  itemShippingAddresses: [],
-  totalLineItemQuantity: 2,
+  ...fullPriceData(29778, 35437, 5659),
+  taxedShippingPrice: taxedPrice(),
+  discountOnTotalPrice: discountOnTotalPrice(4836, 4450, 5295),
 };
+
+export const multipleItemsCartWithUnitPriceTaxMode: CartPropsImportantForMappingTests =
+  {
+    ...defaultRelevantForMappingCTCartParams,
+    lineItems: [
+      {
+        name: {
+          en: 'Bag ”Amanda B” Liebeskind brown',
+        },
+        variant: {
+          sku: 'A0E2000000024BC',
+        },
+        price: {
+          value: centPrice(19999),
+        },
+        quantity: 3,
+        lineItemMode: 'Standard',
+        ...fullPriceData(46887, 55797, 8910),
+      },
+    ],
+    ...fullPriceData(40791, 48543, 7752),
+    discountOnTotalPrice: discountOnTotalPrice(7254, 6096, 7254),
+    taxCalculationMode: 'UnitPriceLevel',
+  };

--- a/paypal-commercetools-extension/tests/constants.ts
+++ b/paypal-commercetools-extension/tests/constants.ts
@@ -56,7 +56,7 @@ const taxedPrice = (
   taxPortions: [],
 });
 
-const fullPriceData = (
+export const fullPriceData = (
   totalNet = 0,
   totalGross = 0,
   totalTax = 0,
@@ -66,8 +66,6 @@ const fullPriceData = (
   totalPrice: centPrice(totalGross),
   taxRate: { amount: taxRateAmount },
 });
-
-export const prices = fullPriceData(16303, 19400, 3097);
 
 const giftLineItem: LineItemPropsImportantForMappingTests = {
   name: {

--- a/paypal-commercetools-extension/tests/constants.ts
+++ b/paypal-commercetools-extension/tests/constants.ts
@@ -12,7 +12,6 @@ import { UpdateActions } from '../src/types/index.types';
 
 type PaymentStateMapData = [string, UpdateActions, boolean];
 
-type LineItemPropsImportantForMappingTests = Pick<
 export const dummyValidPaymentStatusData: Pick<
   Payment,
   'paymentStatus' | 'paymentMethodInfo'
@@ -67,6 +66,7 @@ export const paymentStateMappingWithResults: PaymentStateMapData[] = [
   ['up to date payment', upToDateDummyActions, true],
 ];
 
+type RelevantQuantityIndependentLineItemProps = Pick<
   LineItem,
   'name' | 'lineItemMode' | 'quantity'
 > & {

--- a/paypal-commercetools-extension/tests/constants.ts
+++ b/paypal-commercetools-extension/tests/constants.ts
@@ -5,7 +5,7 @@ import {
   LineItem,
   Price,
   ProductVariant,
-  TaxedItemPrice,
+  TaxedPrice,
   TaxRate,
 } from '@commercetools/platform-sdk';
 
@@ -14,23 +14,27 @@ type LineItemPropsImportantForMappingTests = Pick<
   'name' | 'lineItemMode' | 'quantity'
 > & {
   variant: Pick<ProductVariant, 'sku'>;
-} & { price: Pick<Price, 'value'> } & {
+  price: Pick<Price, 'value'>;
   taxRate?: Pick<TaxRate, 'amount'>;
 };
+
+type TaxedPricePropsImportantForMappingTests = Omit<TaxedPrice, 'taxPortions'>;
 
 type CartPropsImportantForMappingTests = Pick<
   Cart,
   | 'totalPrice'
-  | 'taxedPrice'
   | 'discountOnTotalPrice'
   | 'taxCalculationMode'
   | 'taxMode'
   | 'taxRoundingMode'
   | 'priceRoundingMode'
   | 'directDiscounts'
-  | 'taxedShippingPrice'
   | 'discountCodes'
-> & { lineItems: LineItemPropsImportantForMappingTests[] };
+> & {
+  lineItems: LineItemPropsImportantForMappingTests[];
+  taxedPrice: TaxedPricePropsImportantForMappingTests;
+  taxedShippingPrice?: TaxedPricePropsImportantForMappingTests;
+};
 
 export const longTestTimeoutMs = 20000;
 
@@ -49,22 +53,23 @@ const taxedPrice = (
   totalNet = 0,
   totalGross = 0,
   totalTax = 0
-): TaxedItemPrice => ({
+): TaxedPricePropsImportantForMappingTests => ({
   totalGross: centPrice(totalGross),
   totalNet: centPrice(totalNet),
   totalTax: centPrice(totalTax),
-  taxPortions: [],
 });
+
+const DEFAULT_EU_TAX_RATE = 0.19;
 
 export const fullPriceData = (
   totalNet = 0,
   totalGross = 0,
   totalTax = 0,
-  taxRateAmount = 0.19
+  taxRate = DEFAULT_EU_TAX_RATE
 ) => ({
   taxedPrice: taxedPrice(totalNet, totalGross, totalTax),
   totalPrice: centPrice(totalGross),
-  taxRate: { amount: taxRateAmount },
+  taxRate: { amount: taxRate },
 });
 
 const giftLineItem: LineItemPropsImportantForMappingTests = {
@@ -138,7 +143,6 @@ export const cartWithExternalRate: CartPropsImportantForMappingTests = {
     {
       name: {
         en: 'Bag ”Amanda B” Liebeskind red',
-        de: 'Tasche „Amanda B” Liebeskind rot',
       },
       variant: {
         sku: 'A0E2000000024BD',

--- a/paypal-commercetools-extension/tests/map.utils.spec.ts
+++ b/paypal-commercetools-extension/tests/map.utils.spec.ts
@@ -137,7 +137,7 @@ describe('Testing map utilities', () => {
   );
 });
 
-describe('Testing PayPal breakdown mapping', () => {
+describe('Testing PayPal breakdown mapping for all methods except PayUponInvoice', () => {
   test.each([
     [false, 'LineItemLevel', discountedLineItems, null],
     [true, 'LineItemLevel', undefined, null],
@@ -185,6 +185,7 @@ describe('Testing PayPal breakdown mapping', () => {
         matchingAmounts,
         true,
         isLineItemLevel,
+        false,
         lineItems
       );
       if (!result) expect(lineItemsMap).toBeNull();
@@ -200,13 +201,14 @@ describe('Testing PayPal breakdown mapping', () => {
 const paypalToCTEur = (payPalMoneyValue: string) =>
   parseFloat(payPalMoneyValue);
 
-describe('Testing valid PayPal price breakdown mapping', () => {
+describe('Testing valid PayPal price breakdown mapping for all methods except Pay Upon Invoise', () => {
   test.each([[cartWithExternalRate]])('breakdown mapping', (cart: Cart) => {
     const paypalPrice = mapCommercetoolsCartToPayPalPriceBreakdown(cart);
     const payPalItems = mapValidCommercetoolsLineItemsToPayPalItems(
       true,
       true,
       cart.taxCalculationMode,
+      false,
       cart.lineItems
     );
     expect(paypalPrice).toBeDefined();

--- a/paypal-commercetools-extension/tests/map.utils.spec.ts
+++ b/paypal-commercetools-extension/tests/map.utils.spec.ts
@@ -1,7 +1,13 @@
-import { Cart, LineItem, TypedMoney } from '@commercetools/platform-sdk';
+import {
+  Cart,
+  LineItem,
+  Payment,
+  TypedMoney,
+} from '@commercetools/platform-sdk';
 import { describe, test } from '@jest/globals';
 import { RefundStatusEnum } from '../src/paypal/payments_api';
 import {
+  isPaymentUpToDate,
   mapCommercetoolsCarrierToPayPalCarrier,
   mapCommercetoolsCartToPayPalPriceBreakdown,
   mapCommercetoolsMoneyToPayPalMoney,
@@ -13,12 +19,28 @@ import {
 import {
   cartWithExternalRate,
   discountedLineItems,
+  dummyValidPaymentStatusData,
+  lineItemFromLineItemData,
   multipleItemsCartWithUnitPriceTaxMode,
+  paymentStateMappingWithResults,
 } from './constants';
 
 const refundStatusEnum = (status: string) => {
   return status as RefundStatusEnum;
 };
+
+describe('isPaymentUpToDate verification', () => {
+  test.each(paymentStateMappingWithResults)(
+    'testing %p with payment %p and actions %p results in %p up to date state',
+    (description, actions, result) => {
+      const isUpToDate = isPaymentUpToDate(
+        dummyValidPaymentStatusData as Payment,
+        actions
+      );
+      expect(isUpToDate).toEqual(result);
+    }
+  );
+});
 
 describe('Test payment source mapping', () => {
   test.each([

--- a/paypal-commercetools-extension/tests/payment.controller.spec.ts
+++ b/paypal-commercetools-extension/tests/payment.controller.spec.ts
@@ -15,7 +15,7 @@ const mockConfigModule = () => {
         locale: 'en',
         lineItems: discountedLineItems,
         ...prices,
-        discountOnTotalPrice,
+        discountOnTotalPrice: discountOnTotalPrice(500, 420, 500),
         billingAddress: {
           postalCode: '12345',
           country: 'DE',

--- a/paypal-commercetools-extension/tests/payment.controller.spec.ts
+++ b/paypal-commercetools-extension/tests/payment.controller.spec.ts
@@ -14,7 +14,7 @@ const mockConfigModule = () => {
       return {
         locale: 'en',
         lineItems: discountedLineItems,
-        ...prices,
+        ...fullPriceData(16303, 19400, 3097),
         discountOnTotalPrice: discountOnTotalPrice(500, 420, 500),
         billingAddress: {
           postalCode: '12345',
@@ -47,8 +47,8 @@ import {
   discountedLineItems,
   discountedLineitemWithTaxIncluded,
   discountOnTotalPrice,
+  fullPriceData,
   longTestTimeoutMs,
-  prices,
 } from './constants';
 import { getCart } from '../src/service/commercetools.service';
 

--- a/paypal-commercetools-extension/tests/payment.controller.spec.ts
+++ b/paypal-commercetools-extension/tests/payment.controller.spec.ts
@@ -14,8 +14,12 @@ const mockConfigModule = () => {
       return {
         locale: 'en',
         lineItems: discountedLineItems,
-        ...fullPriceData(16303, 19400, 3097),
-        discountOnTotalPrice: discountOnTotalPrice(500, 420, 500),
+        ...fullPriceData({ gross: 19400, net: 16303, tax: 3097 }),
+        discountOnTotalPrice: discountOnTotalPrice({
+          gross: 500,
+          net: 420,
+          amount: 500,
+        }),
         billingAddress: {
           postalCode: '12345',
           country: 'DE',

--- a/paypal-commercetools-extension/tests/webhooks.controller.spec.ts
+++ b/paypal-commercetools-extension/tests/webhooks.controller.spec.ts
@@ -1,9 +1,16 @@
 import { describe, expect, test } from '@jest/globals';
 import { Response } from 'express';
-import { CheckoutPaymentIntent } from '../src/paypal/checkout_api';
+import {
+  CheckoutPaymentIntent,
+  PaymentSourceResponse,
+} from '../src/paypal/checkout_api';
 
 let apiRequest: any = undefined;
 let apiRoot: any = undefined;
+
+const mockPayPalPaymentSource: PaymentSourceResponse = {
+  card: { name: 'TEST' },
+};
 
 const mockConfigModule = () => {
   apiRoot = {
@@ -27,39 +34,46 @@ const mockConfigModule = () => {
     getWebhookId: () => 1,
     getPayPalOrder: () => ({
       status: 'COMPLETED',
+      payment_source: mockPayPalPaymentSource,
     }),
   }));
   return apiRoot;
 };
 mockConfigModule();
 
-const actual = jest.requireActual('../src/utils/response.utils');
-const spy = jest.spyOn(actual, 'sleep');
+const responseUtilsActual = jest.requireActual('../src/utils/response.utils');
+const spyOnSleep = jest.spyOn(responseUtilsActual, 'sleep');
+
+import { logger } from '../src/utils/logger.utils';
+jest.mock('../src/utils/logger.utils', () => ({
+  logger: { info: jest.fn(), error: jest.fn() },
+}));
 
 import { post } from '../src/controllers/webhook.controller';
 import { longTestTimeoutMs } from './constants';
+import { Capture2StatusEnum } from '../src/paypal/payments_api';
+
+const mockAutrhorizedPayment = {
+  id: 1,
+  transactions: [
+    {
+      type: 'Charge',
+      interactionId: 1,
+      state: 'Success',
+    },
+  ],
+  paymentStatus: {
+    interfaceCode: 'APPROVED',
+    interfaceText: 'APPROVED',
+  },
+  paymentMethodInfo: {
+    method: 'card (TEST)',
+  },
+};
 
 const mockPaymentBody = {
   body: {
-    total: 1,
-    results: [
-      {
-        id: 1,
-        transactions: [
-          {
-            type: 'Charge',
-            interactionId: 1,
-          },
-        ],
-        paymentStatus: {
-          interfaceCode: 'APPROVED',
-          interfaceText: 'APPROVED',
-        },
-        paymentMethodInfo: {
-          method: 'someValidPayPalCredentials',
-        },
-      },
-    ],
+    results: [mockAutrhorizedPayment],
   },
 };
 
@@ -86,24 +100,33 @@ const mockCustomerBody = {
   },
 };
 
+const response = {
+  status: jest.fn(() => response),
+  json: jest.fn(),
+} as unknown as Response;
+
 const expectSuccessfulResponse = async (
   request: any,
   executeCalls: number,
-  actionsCount: number,
-  action: string
+  expectedActions: string[]
 ) => {
-  const response = {
-    status: jest.fn(() => response),
-    json: jest.fn(),
-  } as unknown as Response;
   await post(request, response);
   expect(response.status).toHaveBeenCalledTimes(1);
   expect(response.status).toHaveBeenCalledWith(200);
   expect(apiRequest.execute).toHaveBeenCalledTimes(executeCalls);
-  expect(apiRoot.post.mock.calls[0][0].body.actions).toHaveLength(actionsCount);
-  expect(apiRoot.post.mock.calls[0][0].body.actions[0].action).toBe(action);
+  const actions = apiRoot.post.mock.calls[0][0].body.actions;
+  expect(actions).toHaveLength(expectedActions.length);
+  expectedActions.forEach((expectedAction, index) =>
+    expect(actions[index].action).toEqual(expectedAction)
+  );
 };
-describe('Testing webhook controller', () => {
+
+const expectedUpdatePaymentActions = [
+  'setStatusInterfaceCode',
+  'setStatusInterfaceText',
+  'setMethodInfoMethod',
+];
+describe('Testing webhook controller success scenarios', () => {
   beforeEach(() => {
     apiRequest = {
       execute: jest
@@ -117,40 +140,37 @@ describe('Testing webhook controller', () => {
 
   test.each([
     {
-      name: 'test capture with existing transaction',
+      name: 'capture with existing transaction (update transaction state)',
       resource_type: 'capture',
       resource: { id: 1 },
-      action: 'changeTransactionState',
+      actions: ['changeTransactionState', ...expectedUpdatePaymentActions],
       executeCalls: 2,
-      actionsCount: 3,
     },
     {
-      name: 'test payment_token',
+      name: 'payment_token',
       resource_type: 'payment_token',
       resource: { id: 1, customer: { id: 123 }, metadata: { order_id: 2 } },
-      action: 'setCustomType',
+      actions: ['setCustomType'],
       executeCalls: 4,
-      actionsCount: 1,
     },
     {
-      name: 'test order with authorization with missing transaction',
+      name: 'checkout order with authorization',
       resource_type: 'checkout-order',
       resource: { id: 1, intent: CheckoutPaymentIntent.Authorize },
-      action: 'setStatusInterfaceCode',
-      executeCalls: 2,
-      actionsCount: 2,
-    },
-    {
-      name: 'test authorization with missing transaction',
-      resource_type: 'authorization',
-      resource: { id: 1 },
-      action: 'addTransaction',
+      actions: expectedUpdatePaymentActions,
       executeCalls: 2,
       actionsCount: 3,
+    },
+    {
+      name: 'authorization with missing transaction (create new transaction)',
+      resource_type: 'authorization',
+      resource: { id: 1 },
+      actions: ['addTransaction', ...expectedUpdatePaymentActions],
+      executeCalls: 2,
     },
   ])(
     '$name',
-    async ({ action, resource, resource_type, executeCalls, actionsCount }) => {
+    async ({ actions, resource, resource_type, executeCalls }) => {
       const request = {
         header: jest.fn(),
         body: {
@@ -160,16 +180,22 @@ describe('Testing webhook controller', () => {
           summary: 'Capture is done.',
         },
       } as any;
-      await expectSuccessfulResponse(
-        request,
-        executeCalls,
-        actionsCount,
-        action
-      );
+      await expectSuccessfulResponse(request, executeCalls, actions);
     },
     longTestTimeoutMs
   );
 });
+
+const mockTokenRequest = {
+  header: jest.fn(),
+  body: {
+    resource_type: 'payment_token',
+    resource: {
+      customer: { id: 'customer_id' },
+      metadata: { order_id: 'order_id' },
+    },
+  },
+} as any;
 
 describe('test retry fetch cart', () => {
   beforeEach(() => {
@@ -186,19 +212,9 @@ describe('test retry fetch cart', () => {
   test(
     'refetch cart once',
     async () => {
-      expect(spy).not.toHaveBeenCalled();
-      const request = {
-        header: jest.fn(),
-        body: {
-          resource_type: 'payment_token',
-          resource: {
-            customer: { id: 'customer_id' },
-            metadata: { order_id: 'order_id' },
-          },
-        },
-      } as any;
-      await expectSuccessfulResponse(request, 5, 1, 'setCustomType');
-      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spyOnSleep).not.toHaveBeenCalled();
+      await expectSuccessfulResponse(mockTokenRequest, 5, ['setCustomType']);
+      expect(spyOnSleep).toHaveBeenCalledTimes(1);
     },
     longTestTimeoutMs
   );
@@ -217,24 +233,53 @@ describe('test cart could not be fetched', () => {
   test(
     'refetch cart did not succeed',
     async () => {
-      expect(spy).not.toHaveBeenCalled();
+      expect(spyOnSleep).not.toHaveBeenCalled();
+      await post(mockTokenRequest, response);
+      expect(spyOnSleep).toHaveBeenCalled();
+      expect(apiRoot.post).not.toHaveBeenCalled();
+    },
+    longTestTimeoutMs
+  );
+});
+
+describe('transaction is already up to date', () => {
+  beforeEach(() => {
+    apiRequest = {
+      execute: jest
+        .fn()
+        .mockReturnValueOnce({
+          body: {
+            results: [
+              {
+                ...mockAutrhorizedPayment,
+                paymentStatus: {
+                  interfaceCode: 'COMPLETED',
+                  interfaceText: 'COMPLETED',
+                },
+              },
+            ],
+          },
+        })
+        .mockReturnValueOnce(mockCartBody),
+    };
+    jest.clearAllMocks();
+  });
+  test(
+    '',
+    async () => {
       const request = {
         header: jest.fn(),
         body: {
-          resource_type: 'payment_token',
-          resource: {
-            customer: { id: 'customer_id' },
-            metadata: { order_id: 'order_id' },
-          },
+          resource_type: 'capture',
+          event_type: 'Captured',
+          resource: { id: 1, status: Capture2StatusEnum.Completed },
+          summary: 'Capture is done.',
         },
       } as any;
-      const response = {
-        status: jest.fn(() => response),
-        json: jest.fn(),
-      } as unknown as Response;
       await post(request, response);
-      expect(spy).toHaveBeenCalled();
-      expect(apiRoot.post).not.toHaveBeenCalled();
+      expect(logger.info).toHaveBeenLastCalledWith(
+        'No update actions required within the webhook call for payment 1 in scope of CapturePayPalOrderWebhook, both transaction and payment statuses are already up to date'
+      );
     },
     longTestTimeoutMs
   );
@@ -261,23 +306,25 @@ describe('customer not found', () => {
     jest.clearAllMocks();
   });
   test('cart fetched success but no customer associated with it', async () => {
-    expect(spy).not.toHaveBeenCalled();
-    const request = {
-      header: jest.fn(),
-      body: {
-        resource_type: 'payment_token',
-        resource: {
-          customer: { id: 'customer_id' },
-          metadata: { order_id: 'order_id' },
-        },
-      },
-    } as any;
-    const response = {
-      status: jest.fn(() => response),
-      json: jest.fn(),
-    } as unknown as Response;
-    await post(request, response);
-    expect(spy).not.toHaveBeenCalled();
+    expect(spyOnSleep).not.toHaveBeenCalled();
+    await post(mockTokenRequest, response);
+    expect(spyOnSleep).not.toHaveBeenCalled();
     expect(apiRoot.post).not.toHaveBeenCalled();
+  });
+});
+
+describe('payment not found for the PayPal order', () => {
+  beforeEach(() => {
+    apiRequest = {
+      execute: jest.fn().mockReturnValueOnce({ body: { results: [] } }),
+    };
+  });
+  test('no related payment', async () => {
+    expect(logger.error).not.toHaveBeenCalled();
+    await post(mockTokenRequest, response);
+    expect(logger.error).toHaveBeenCalledTimes(1);
+    expect(logger.error).toHaveBeenLastCalledWith(
+      `PayPalPaymentTokenWebhook action impossible - there is not any assigned commercetools payment for the PayPal order id order_id`
+    );
   });
 });

--- a/paypal-commercetools-extension/yarn.lock
+++ b/paypal-commercetools-extension/yarn.lock
@@ -740,18 +740,14 @@
     triple-beam "1.4.1"
     winston "3.13.0"
 
-"@commercetools/platform-sdk@^7.22.0":
-  version "7.25.1"
-  resolved "https://registry.yarnpkg.com/@commercetools/platform-sdk/-/platform-sdk-7.25.1.tgz#32ce64ac7f6ea0423b43363734de2c297be5294e"
-  integrity sha512-GIfq3FN1JijElR4y3JZxLqu1S98IJ16UtWbAfwUqDnbBOREXpH52fdd5fHBMKpqXSxaYkzcmHLH+qrwlqWHQ7A==
+"@commercetools/platform-sdk@^8.18.0":
+  version "8.18.0"
+  resolved "https://registry.yarnpkg.com/@commercetools/platform-sdk/-/platform-sdk-8.18.0.tgz#8dd61ad589c130a8cd1827623a1a0e08506c3eee"
+  integrity sha512-x7jlaYWRsEhKRd0pXuTkLby91PNpHKJDDnJFZt8P+xPNEkzzoCaWxVx1VM89gr8hagPzTwXIjz4vUNb30sFpIQ==
   dependencies:
-    "@commercetools/sdk-client-v2" "^2.5.0"
-    "@commercetools/sdk-middleware-auth" "^7.0.0"
-    "@commercetools/sdk-middleware-http" "^7.0.0"
-    "@commercetools/sdk-middleware-logger" "^3.0.0"
-    "@commercetools/ts-client" "^2.1.7"
+    "@commercetools/ts-client" "^4.3.0"
 
-"@commercetools/sdk-client-v2@^2.0.0", "@commercetools/sdk-client-v2@^2.5.0":
+"@commercetools/sdk-client-v2@^2.0.0":
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/@commercetools/sdk-client-v2/-/sdk-client-v2-2.5.0.tgz#3fe33f733d059472896f4fd0820cf899a30cd150"
   integrity sha512-v1y++O6yllG+IRTYm9jPE8s667+GapnysyGIf8NJDZbVwhvcanixZL4d20imXjCpOr4u1iZrgRftc90mgYqblw==
@@ -759,31 +755,12 @@
     buffer "^6.0.3"
     node-fetch "^2.6.1"
 
-"@commercetools/sdk-middleware-auth@^7.0.0":
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/@commercetools/sdk-middleware-auth/-/sdk-middleware-auth-7.0.1.tgz#20260740a423589d9210747e460f8ca917b3787b"
-  integrity sha512-XLRm+o3Yd0mkVoyzsOA98PUu0U0ajQdBHMhZ8N2XMOtL4OY8zsgT8ap5JneXV8zWZNiwIYYAYoUDwBlLZh2lAQ==
+"@commercetools/ts-client@^4.3.0":
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/@commercetools/ts-client/-/ts-client-4.7.0.tgz#86c9e34d13f62427193c6f712e3ab87ffaaebfc4"
+  integrity sha512-UfzV7hWJ1Vu127swOLa62VeRAiIGIXihcUrbOVGsdXtRPGQ/AjsCw1ySqp/cwL99FAGyf6+L7yRQY9snAHZ1DQ==
   dependencies:
-    node-fetch "^2.6.7"
-
-"@commercetools/sdk-middleware-http@^7.0.0":
-  version "7.0.4"
-  resolved "https://registry.yarnpkg.com/@commercetools/sdk-middleware-http/-/sdk-middleware-http-7.0.4.tgz#ea4522c45d6fc436ff82e1d6a9d969192289821f"
-  integrity sha512-YpBDTA1NqjfwqPxrll6FzDc0A7hLSRwd9OLGMlPcvUG2Je1ks8Pe34pLdPqz7jgdURwfFXRBmXxPhezDzMbnZA==
-
-"@commercetools/sdk-middleware-logger@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@commercetools/sdk-middleware-logger/-/sdk-middleware-logger-3.0.0.tgz#4bfc7441d485b3f1046001f44200d12926accb84"
-  integrity sha512-DhMXAA2yIch/AaGxy7st85Z1HFmeLtHWGkr9z5rX4xKjan4PHGB/IE5saAR+SNGHhs6+1Lp8vZEHDo3tFqVLmg==
-
-"@commercetools/ts-client@^2.1.7":
-  version "2.1.8"
-  resolved "https://registry.yarnpkg.com/@commercetools/ts-client/-/ts-client-2.1.8.tgz#d2e4a8829c82ac9f5d6e90b6b5ff3b5992cc8986"
-  integrity sha512-ESA4dPB7MlitDnERLhbALXamukyZcqSA/gPgK11dJ/36OjkEPZyaS+5mEGXP9DnvneOYGf7Q94mmtVXcEpm7qg==
-  dependencies:
-    abort-controller "3.0.0"
     buffer "^6.0.3"
-    node-fetch "^2.6.1"
 
 "@dabh/diagnostics@^2.0.2":
   version "2.0.8"
@@ -2095,13 +2072,6 @@
   resolved "https://registry.yarnpkg.com/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz#538b1e103bf8d9864e7b85cc96fa8d6fb6c40777"
   integrity sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==
 
-abort-controller@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/abort-controller/-/abort-controller-3.0.0.tgz#eaf54d53b62bae4138e809ca225c8439a6efb392"
-  integrity sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==
-  dependencies:
-    event-target-shim "^5.0.0"
-
 accepts@~1.3.8:
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.8.tgz#0bf0be125b67014adcb0b0921e62db7bffe16b2e"
@@ -2970,11 +2940,6 @@ etag@~1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==
-
-event-target-shim@^5.0.0:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
-  integrity sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
 
 execa@^5.1.1:
   version "5.1.1"
@@ -4390,7 +4355,7 @@ ngrok@^5.0.0-beta.2:
   optionalDependencies:
     hpagent "^0.1.2"
 
-node-fetch@^2.6.1, node-fetch@^2.6.7:
+node-fetch@^2.6.1:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
   integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==


### PR DESCRIPTION
the aim of the branch is to cover all tax modes and price rounding supported by commercetools to properly map to PayPal order (not just default one supported now)